### PR TITLE
feat: show UBOs where specified in the source.

### DIFF
--- a/e2e/donor.spec.ts
+++ b/e2e/donor.spec.ts
@@ -2,7 +2,9 @@ import { expect } from "@playwright/test";
 
 import { test } from "./util/fixture";
 import { hash } from "../tasks/load-data/util";
-import { DONOR_WITH_WIKIPEDIA_ARTICLE } from "../tests/config";
+import { DONOR_WITH_UBOs, DONOR_WITH_WIKIPEDIA_ARTICLE } from "../tests/config";
+
+import { formatAnd } from "@/utils/formatter";
 
 test.describe("Donor page", () => {
   test("works as expected", async ({
@@ -42,6 +44,24 @@ test.describe("Donor page", () => {
       await test.step("is accessible", async () => {
         await accessibility.check();
       });
+    });
+  });
+
+  test("shows UBOs if known", async ({
+    page,
+    donorPage,
+    baseURL,
+    accessibility,
+    locale,
+  }) => {
+    await page.goto(`${baseURL}/germany/donor/${hash(DONOR_WITH_UBOs)}`);
+
+    await expect(donorPage.uboText).toHaveText(
+      formatAnd(locale, ["Fake UBO 1", "Fake UBO 2"]),
+    );
+
+    await test.step("is accessible", async () => {
+      await accessibility.check();
     });
   });
 });

--- a/e2e/fixtures/donor.ts
+++ b/e2e/fixtures/donor.ts
@@ -9,4 +9,7 @@ export class DonorPage extends PageObject {
     this.props,
   );
   public readonly pageTitle = this.page.locator("#sec-donor-overview");
+  public readonly uboText = this.page.locator(
+    'section[aria-labelledby="ubo-heading"] p',
+  );
 }

--- a/src/app/[locale]/[country]/donor/[donorId]/donor-page-head.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/donor-page-head.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { HatGlasses, Lock } from "lucide-react";
+import { HatGlasses, Info, Lock } from "lucide-react";
 
 import { AbsoluteMultipleColorsGradient } from "../../../../../components/absolute-multiple-colors-gradient";
 import { PageHeader } from "../../../../../components/layout/page-header";
@@ -14,6 +14,7 @@ import { useTranslations } from "../../../../../hooks/use-translations";
 import { partyColor } from "../../../../../utils/color";
 import { donationYear } from "../../../../../utils/date";
 import {
+  formatAnd,
   formatCountryCurrency,
   formatNumber,
   formatYearsRange,
@@ -135,6 +136,25 @@ const RedactedDonorTooltip = ({
   );
 };
 
+const UBOsTooltip = ({ translations }: { translations: Translations }) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={<div className="ml-1 inline-block cursor-help" tabIndex={0} />}
+      >
+        <Info size={16} />
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="max-w-80 p-1">
+          <p className="text-xs leading-relaxed opacity-90">
+            {translations.donor.ubo_description}
+          </p>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
 const DonorPageHeadContent = ({
   countryConfig,
   donations,
@@ -156,6 +176,7 @@ const DonorPageHeadContent = ({
   const firstYear = donationYear(donations[0]);
   const lastYear = donationYear(donations[donations.length - 1]);
   let lastDonation: string | undefined = undefined;
+  const ubos = new Set<string>();
 
   donations.forEach((donation) => {
     sums[donation[DonationField.Receiver]] ??= 0;
@@ -165,6 +186,8 @@ const DonorPageHeadContent = ({
     if (!lastDonation || donation[DonationField.Date] > lastDonation) {
       lastDonation = donation[DonationField.Date];
     }
+
+    donation[DonationField.UBOs]?.forEach((ubo) => ubos.add(ubo));
   });
 
   const avg = sum / donations.length;
@@ -291,6 +314,20 @@ const DonorPageHeadContent = ({
                   ))}
                 </div>
               </div>
+            ) : null}
+            {ubos.size > 0 ? (
+              <section aria-labelledby="ubo-heading">
+                <MetaCardTitle
+                  id="ubo-heading"
+                  title={
+                    <>
+                      {translations.donor.ubo}
+                      <UBOsTooltip translations={translations} />
+                    </>
+                  }
+                />
+                <p className="mt-2">{formatAnd(locale, [...ubos])}</p>
+              </section>
             ) : null}
           </div>
           <div className="mb-3">

--- a/src/components/meta-card.tsx
+++ b/src/components/meta-card.tsx
@@ -3,12 +3,15 @@ import type { JSX } from "react";
 export const MetaCardTitle = ({
   variant,
   title,
+  id,
 }: {
-  title: string;
+  title: string | JSX.Element;
   variant?: "default" | "small";
+  id?: string;
 }) => {
   return (
     <div
+      id={id}
       className={`${
         variant === "small" ? "text-sm" : "text-base"
       } mb-1 leading-none text-slate-500 dark:text-slate-300`}

--- a/src/hooks/use-api.ts
+++ b/src/hooks/use-api.ts
@@ -130,7 +130,7 @@ export const useDonationsByDonorId = (
         .then((data) =>
           // Filter donations by donor ID
           donationDocumentToDonations(data, (donation) => {
-            const [, donationDonorId] =
+            const [, , /* name */ /* ubos */ donationDonorId] =
               data.donors[donation[DonationField.DonorIndex]];
             return donationDonorId === donorId;
           }),

--- a/src/lib/api/donations-document.ts
+++ b/src/lib/api/donations-document.ts
@@ -7,12 +7,12 @@ type DocumentDonation = Omit<Donation, DonationField.DonorName> & {
 };
 
 export interface DonationsDocument {
-  donors: [donorName: string, donorId: string][];
+  donors: [donorName: string, ubos: string[] | null, donorId: string][];
   donations: DocumentDonation[];
 }
 
 export interface DonationsDocumentWithoutDonorIds {
-  donors: [donorName: string][];
+  donors: [donorName: string, ubos: string[] | null][];
   donations: DocumentDonation[];
 }
 
@@ -22,11 +22,12 @@ export const donationDocumentDonationToDonation = (
   donation: DocumentDonation,
 ): Donation => {
   const donorIndex = donation[DonationField.DonorIndex];
-  const [donorName] = doc.donors[donorIndex];
+  const [donorName, ubos] = doc.donors[donorIndex];
 
   return {
     ...donation,
     [DonationField.DonorName]: donorName,
+    ...(ubos ? { [DonationField.UBOs]: ubos } : undefined),
   };
 };
 

--- a/src/messages/cs.ts
+++ b/src/messages/cs.ts
@@ -549,6 +549,9 @@ const Cs = {
       description:
         "Identita dárce byla před zveřejněním těchto údajů redigována zveřejňujícím orgánem. Výše daru zůstává zahrnuta ve výpočtech celkového financování, aby byla zachována finanční transparentnost.",
     },
+    ubo: "Konečný skutečný vlastník (KSV)",
+    ubo_description:
+      'Konečný skutečný vlastník (KSV) je osoba, která skutečně táhne za nitky. Jedná se o jednotlivce, kteří v konečném důsledku vlastní nebo kontrolují dárce, typicky držením 25 % nebo více jeho akcií nebo hlasovacích práv. Pokud žádná jednotlivá osoba nesplňuje tuto hranici, může být vrcholný management (například ředitelé) uveden jako "pseudo-KSV" k zajištění odpovědnosti.',
   },
   countries: {
     "??": "Neuvedeno",

--- a/src/messages/de.ts
+++ b/src/messages/de.ts
@@ -544,6 +544,9 @@ const De = {
       description:
         "Die Identität der Spenderin bzw. des Spenders wurde von der veröffentlichenden Behörde vor der Veröffentlichung dieser Daten geschwärzt. Der Spendenbetrag bleibt in den Berechnungen der Gesamtfinanzierung enthalten, um die finanzielle Transparenz zu wahren.",
     },
+    ubo: "Wirtschaftlich Berechtigte (WBs)",
+    ubo_description:
+      'Ein wirtschaftlich Berechtigter (WB) ist die Person, die tatsächlich die Fäden zieht. Es handelt sich um die Personen, die letztendlich den Spender besitzen oder kontrollieren, typischerweise durch das Halten von 25% oder mehr seiner Anteile oder Stimmrechte. Wenn keine einzelne Person diese Schwelle erreicht, können Führungskräfte (wie Geschäftsführer) als "Pseudo-WBs" aufgeführt werden, um die Rechenschaftspflicht sicherzustellen.',
   },
   countries: {
     "??": "Nicht angegeben",

--- a/src/messages/en.ts
+++ b/src/messages/en.ts
@@ -511,6 +511,9 @@ const En = {
       description:
         "The donor's identity was redacted by the publishing authority prior to the release of this data. The donation amount remains included in the total funding calculations to maintain financial transparency.",
     },
+    ubo: "Ultimate beneficial owners (UBOs)",
+    ubo_description:
+      'An Ultimate Beneficial Owner (UBO) is the person who actually pulls the strings. They are the individuals who ultimately own or control the donor, typically by holding 25% or more of its shares or voting rights. If no single person meets this threshold, senior management (like Directors) may be listed as "pseudo-UBOs" to ensure accountability.',
   },
   countries: {
     "??": "Not specified",

--- a/src/messages/et.ts
+++ b/src/messages/et.ts
@@ -560,6 +560,9 @@ const Et = {
       description:
         "Avaldav asutus varjas annetaja isikuandmed enne nende andmete avaldamist. Annetuse summa on siiski kogurahastuse arvutustes arvesse võetud, et säilitada finantsläbipaistvus.",
     },
+    ubo: "Tegelikud kasusaajad (TK)",
+    ubo_description:
+      'Tegelik kasusaaja (TK) on isik, kes tegelikult niite tõmbab. Need on üksikisikud, kes lõpuks omavad või kontrollivad annetajat, tavaliselt omades 25% või rohkem tema aktsiatest või hääleõigustest. Kui ükski üksikisik ei vasta sellele künnisväärtusele, võidakse kõrgem juhtkond (nagu direktorid) loetleda "pseudo-TK-dena", et tagada vastutus.',
   },
   countries: {
     "??": "Ei ole täpsustatud",

--- a/src/messages/hr.ts
+++ b/src/messages/hr.ts
@@ -504,6 +504,9 @@ const Hr = {
       description:
         "Identitet donatora redigirala je nadležna institucija prije objave ovih podataka. Iznos donacije i dalje je uključen u izračune ukupnog financiranja kako bi se očuvala financijska transparentnost.",
     },
+    ubo: "Stvarni vlasnici (SV)",
+    ubo_description:
+      'Stvarni vlasnik (SV) je osoba koja zapravo vuče konce. To su pojedinci koji u konačnici posjeduju ili kontroliraju donatora, obično držeći 25% ili više njegovih dionica ili glasačkih prava. Ako nijedna pojedinačna osoba ne ispunjava ovaj prag, viši menadžment (poput direktora) može biti naveden kao "pseudo-SV" kako bi se osigurala odgovornost.',
   },
   countries: {
     "??": "Nije navedeno",

--- a/src/messages/lv.ts
+++ b/src/messages/lv.ts
@@ -559,6 +559,9 @@ const Lv = {
       description:
         "Donora identitāti pirms šo datu publicēšanas rediģēja publicējošā iestāde. Ziedojuma summa joprojām ir iekļauta kopējā finansējuma aprēķinos, lai saglabātu finanšu caurspīdīgumu.",
     },
+    ubo: "Patiesie labuma guvēji (PLG)",
+    ubo_description:
+      'Patiesais labuma guvējs (PLG) ir persona, kas faktiski vada procesus. Tie ir indivīdi, kas galu galā pieder vai kontrolē ziedotāju, parasti turot 25% vai vairāk no tā akcijām vai balsstiesībām. Ja neviens atsevišķs cilvēks neatbilst šim slieksnim, augstākā vadība (piemēram, direktori) var tikt norādīti kā "pseudo-PLG", lai nodrošinātu atbildību.',
   },
   countries: {
     "??": "Nav norādīts",

--- a/src/messages/nl.ts
+++ b/src/messages/nl.ts
@@ -555,6 +555,9 @@ const Nl = {
       description:
         "De identiteit van de donor is door de publicerende instantie geredigeerd vóór de publicatie van deze gegevens. Het donatiebedrag blijft opgenomen in de berekeningen van de totale financiering om financiële transparantie te waarborgen.",
     },
+    ubo: "Uiteindelijk belanghebbenden (UBO's)",
+    ubo_description:
+      'Een Uiteindelijk Belanghebbende (UBO) is de persoon die feitelijk aan de touwtjes trekt. Het zijn de individuen die uiteindelijk de donor bezitten of controleren, doorgaans door 25% of meer van de aandelen of stemrechten te houden. Als geen enkele persoon aan deze drempel voldoet, kan het hoger management (zoals directeuren) worden vermeld als "pseudo-UBO\'s" om verantwoordelijkheid te waarborgen.',
   },
   countries: {
     "??": "Niet gespecificeerd",

--- a/src/messages/no.ts
+++ b/src/messages/no.ts
@@ -511,6 +511,9 @@ const No = {
       description:
         "Giverens identitet ble sladdet av den publiserende myndigheten før disse dataene ble offentliggjort. Donasjonsbeløpet er fortsatt inkludert i beregningene av total finansiering for å ivareta finansiell åpenhet.",
     },
+    ubo: "Reelle rettighetshavere (RRH)",
+    ubo_description:
+      'En reell rettighetshaver (RRH) er personen som faktisk styrer. Det er de personene som til syvende og sist eier eller kontrollerer giveren, vanligvis ved å inneha 25 % eller mer av aksjene eller stemmerettighetene. Hvis ingen enkeltperson oppfyller denne terskelen, kan toppledelsen (som direktører) bli oppført som "pseudo-RRH-er" for å sikre ansvarlighet.',
   },
   countries: {
     "??": "Ikke spesifisert",

--- a/src/utils/data/server-loaders.ts
+++ b/src/utils/data/server-loaders.ts
@@ -49,7 +49,7 @@ export async function getDonationsByDonorId(
 
     // Filter donations by donor ID
     return donationDocumentToDonations(data, (donation) => {
-      const [, donationDonorId] =
+      const [, , /* name */ /* ubos */ donationDonorId] =
         data.donors[donation[DonationField.DonorIndex]];
       return donationDonorId === donorId;
     });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -44,6 +44,9 @@ export const enum DonationField {
   Receiver,
   Address,
   DonorIndex,
+  // Ultimate Beneficial Owners
+  // see https://en.wikipedia.org/wiki/Beneficial_ownership
+  UBOs,
 }
 
 export interface Donation {
@@ -56,6 +59,7 @@ export interface Donation {
   [DonationField.Address]: DonationAddress;
   [DonationField.Receiver]: ReceiverId;
   [DonationField.DonorType]?: DonorType;
+  [DonationField.UBOs]?: string[];
 }
 
 export interface Party {

--- a/tasks/fake-data/generate-fake-data.ts
+++ b/tasks/fake-data/generate-fake-data.ts
@@ -3,6 +3,7 @@ import debug from "debug";
 import {
   DONOR_WITH_REL_A,
   DONOR_WITH_REL_B,
+  DONOR_WITH_UBOs,
   DONOR_WITH_WIKIPEDIA_ARTICLE,
 } from "../../tests/config";
 import { DataLoader } from "../load-data/data-loader";
@@ -97,6 +98,17 @@ class FakeDataLoader extends DataLoader {
     extracted.push({
       idx: `fake-${year}-${idx++}`,
       [DonationField.DonorName]: DONOR_WITH_WIKIPEDIA_ARTICLE,
+      [DonationField.Date]: `${year}-01-01`,
+      [DonationField.Amount]: countryConfig.minPublicDonationAmount + 1,
+      [DonationField.Receiver]: this.pickRandomParty(),
+      [DonationField.Address]: { [AddressField.Country]: "??" },
+    } as ExtractedYearData);
+
+    // create fake donation with UBOs
+    extracted.push({
+      idx: `fake-${year}-${idx++}`,
+      [DonationField.DonorName]: DONOR_WITH_UBOs,
+      [DonationField.UBOs]: ["Fake UBO 1", "Fake UBO 2"],
       [DonationField.Date]: `${year}-01-01`,
       [DonationField.Amount]: countryConfig.minPublicDonationAmount + 1,
       [DonationField.Receiver]: this.pickRandomParty(),

--- a/tasks/load-data/nl/nl-loader.ts
+++ b/tasks/load-data/nl/nl-loader.ts
@@ -12,12 +12,52 @@ import { AddressField, DonationField } from "../../../src/utils/types";
 import { DataLoader } from "../data-loader";
 import { donorMeta } from "./donor-meta";
 
-import type { Countries } from "../../../src/utils/locales";
 import type {
   ExtractedDonationAddress,
   ReceiverId,
 } from "../../../src/utils/types";
 import type { ExtractedYearData, PartyConfig } from "../data-loader";
+
+export const uboExtractorAfter2025 = (ubo: string): string[] => {
+  return ubo.split("\n").filter(Boolean);
+};
+
+export const uboExtractor2024 = (
+  uboName: string,
+  uboCityResidence: string,
+): string[] | undefined => {
+  if (uboName || uboCityResidence) {
+    // join each ubo name and city residence line
+    const uboNames = uboName
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const uboCities = uboCityResidence
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    if (uboNames.length > 1 && uboCities.length === 1) {
+      // fill the uboCities for all uboNames if we only have one city residence line but multiple ubo name lines,
+      // as it seems to be the case that they just put the city residence in the first line and left the rest empty
+      uboCities.push(...Array(uboNames.length - 1).fill(uboCities[0]));
+    }
+
+    if (uboNames.length === 1 && uboCities.length > 1) {
+      // remove all except the first uboCities entry as there seems to be a type in some rows :(
+      uboCities.splice(1);
+    }
+
+    assert(
+      uboNames.length === uboCities.length,
+      `UBO name and city residence lines should match: ${uboName} - ${uboCityResidence}`,
+    );
+
+    return uboNames.map(
+      (name, idx) => `${name.trim()}, ${uboCities[idx].trim()}`,
+    );
+  }
+};
 
 export class NlLoader extends DataLoader {
   parties: Record<string, PartyConfig> = {
@@ -314,12 +354,16 @@ export class NlLoader extends DataLoader {
         isoDate = `${year}`;
       }
 
+      const ubos = uboExtractorAfter2025(ubo);
+
       return {
         [DonationField.Date]: isoDate,
         [DonationField.Receiver]: party.trim() as ReceiverId,
         [DonationField.Amount]: total,
         [DonationField.DonorName]: name,
         [DonationField.Address]: this.findAddress(address),
+        // optionally add UBO
+        ...(ubos?.length ? { [DonationField.UBOs]: ubos } : undefined),
       };
     },
     2024: (year, col, idx, rows) => {
@@ -359,8 +403,16 @@ export class NlLoader extends DataLoader {
         };
       };
 
-      const { party, totalAmount, donorName, donorAddress, amount, date } =
-        extractRow(col);
+      const {
+        party,
+        totalAmount,
+        donorName,
+        donorAddress,
+        amount,
+        date,
+        uboName,
+        uboCityResidence,
+      } = extractRow(col);
 
       // skip if we don't have a total amount
       if (!totalAmount) return;
@@ -373,12 +425,16 @@ export class NlLoader extends DataLoader {
         isoDate = `${year}`;
       }
 
+      const ubo = uboExtractor2024(uboName, uboCityResidence);
+
       return {
         [DonationField.Date]: isoDate,
         [DonationField.Receiver]: party.trim() as ReceiverId,
         [DonationField.Amount]: totalAmount,
         [DonationField.DonorName]: donorName,
         [DonationField.Address]: this.findAddress(donorAddress),
+        // optionally add UBO
+        ...(ubo?.length ? { [DonationField.UBOs]: ubo } : undefined),
       };
     },
     2023: (year, col, idx, rows) => {

--- a/tasks/load-data/util.ts
+++ b/tasks/load-data/util.ts
@@ -70,7 +70,7 @@ export const donationsToDonationsDocumentWithoutDonorIds = (
 ): DonationsDocumentWithoutDonorIds => {
   const document = donationsToDonationsDocument(donations);
   return {
-    donors: document.donors.map(([donorName]) => [donorName]),
+    donors: document.donors.map(([donorName, ubos]) => [donorName, ubos]),
     donations: document.donations,
   };
 };
@@ -85,14 +85,26 @@ const donationsToDonationsDocument = (
   donations: Donation[],
 ): DonationsDocument => {
   const donorIds: Record<string, string> = {};
+  const donorUBOs: Record<string, Set<string>> = {};
 
   donations.forEach((donation) => {
     const donorName = donation[DonationField.DonorName];
+    const ubos = donation[DonationField.UBOs];
+
     donorIds[donorName] = hash(donorName);
+
+    if (ubos?.length) {
+      donorUBOs[donorName] ??= new Set([]);
+      ubos.forEach((ubo) => donorUBOs[donorName].add(ubo));
+    }
   });
 
   const document: DonationsDocument = {
-    donors: Object.entries(donorIds),
+    donors: Object.entries(donorIds).map(([donorName, donorId]) => [
+      donorName,
+      donorUBOs[donorName] ? [...donorUBOs[donorName]] : null,
+      donorId,
+    ]),
     donations: [],
   };
   const donorNames = Object.keys(donorIds);
@@ -101,10 +113,14 @@ const donationsToDonationsDocument = (
     const donorName = donation[DonationField.DonorName];
     const donorIndex = donorNames.indexOf(donorName);
 
-    const { [DonationField.DonorName]: _, ...donationWithoutName } = donation;
+    const {
+      [DonationField.DonorName]: _1,
+      [DonationField.UBOs]: _2,
+      ...donationWithStrippedFields
+    } = donation;
 
     document.donations.push({
-      ...donationWithoutName,
+      ...donationWithStrippedFields,
       [DonationField.DonorIndex]: donorIndex,
     });
   });

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -2,6 +2,7 @@ import type { TestContext } from "vitest";
 
 export const IS_FAKE_ENV = process.env.FAKE === "true";
 export const DONOR_WITH_WIKIPEDIA_ARTICLE = "Fake Donor With Wikipedia Article";
+export const DONOR_WITH_UBOs = "Fake Donor With UBOs";
 export const DONOR_WITH_REL_A = "Fake Donor With Relation A";
 export const DONOR_WITH_REL_B = "Fake Donor With Relation B";
 

--- a/tests/data-loader/hr-loader.test.ts
+++ b/tests/data-loader/hr-loader.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
 
-import { currencyConversion } from "../tasks/load-data/hr/hr-loader";
+import { currencyConversion } from "../../tasks/load-data/hr/hr-loader";
 
 describe("currencyConversion", () => {
   test("it doesn't convert entries after 2024", () => {

--- a/tests/data-loader/nl-loader.test.ts
+++ b/tests/data-loader/nl-loader.test.ts
@@ -1,0 +1,37 @@
+import { expect, test, describe } from "vitest";
+
+import {
+  uboExtractor2024,
+  uboExtractorAfter2025,
+} from "../../tasks/load-data/nl/nl-loader";
+
+describe("uboExtractorAfter2025", () => {
+  test("it works", () => {
+    expect(uboExtractorAfter2025("")).toEqual([]);
+    expect(uboExtractorAfter2025("Foo")).toEqual(["Foo"]);
+    expect(uboExtractorAfter2025("Foo\nBar")).toEqual(["Foo", "Bar"]);
+  });
+});
+
+describe("uboExtractor2024", () => {
+  test("it works", () => {
+    expect(uboExtractor2024("Name", "City")).toEqual(["Name, City"]);
+    expect(uboExtractor2024("Name 1\nName 2", "City 1\nCity 2")).toEqual([
+      "Name 1, City 1",
+      "Name 2, City 2",
+    ]);
+  });
+
+  test("some entries have one name and multiple times the same city", () => {
+    expect(uboExtractor2024("Name", "City 1\nCity 1")).toEqual([
+      "Name, City 1",
+    ]);
+  });
+
+  test("some entries have multiple names and only one city", () => {
+    expect(uboExtractor2024("Name 1\nName 2", "City 1")).toEqual([
+      "Name 1, City 1",
+      "Name 2, City 1",
+    ]);
+  });
+});


### PR DESCRIPTION
Currently this is only collected for the Dutch dataset

## Description
The dutch dataset specifies a donors UBO since 2024. This is pretty useful for seeing who's behind a company. 
https://www.swift.com/risk-and-compliance/know-your-customer-kyc/ultimate-beneficial-owner-ubo

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Data update/addition
- [ ] Documentation update
- [ ] Refactoring

## Related Issues
Fixes #(issue number)

## Testing
- [x] Unit tests pass (`pnpm test:unit`)
- [x] Lint passes (`pnpm lint`)
- [x] E2E tests pass (`pnpm test:e2e`) - if UI changes

## Screenshots
<img width="769" height="385" alt="image" src="https://github.com/user-attachments/assets/8c747180-0ea0-4045-9661-f5bd92cfcb0e" />
