### PR TITLE
feat(tools): add initial compare parties tool

### DIFF
--- a/e2e/fixtures/tools.ts
+++ b/e2e/fixtures/tools.ts
@@ -1,15 +1,7 @@
 import { LocatorObject } from "../util/locator";
 import { PageObject } from "../util/page";
 
-class DataExportTool extends LocatorObject {
-  public downloadCSV = this.locator.getByText(
-    this.translations("common.download_format", { format: "CSV" }),
-  );
-  public downloadJSON = this.locator.getByText(
-    this.translations("common.download_format", { format: "JSON" }),
-  );
-}
-class BarChartRaceTool extends LocatorObject {
+class YearRangeFilterTool extends LocatorObject {
   public get legislativeYearsFieldset() {
     return this.locator.locator("fieldset").filter({
       has: this.locator
@@ -40,6 +32,50 @@ class BarChartRaceTool extends LocatorObject {
     });
   }
 
+  public get advancedSection() {
+    return this.locator.locator("details");
+  }
+
+  public get advancedSummary() {
+    return this.advancedSection.locator("summary");
+  }
+
+  public get fromYearDropdown() {
+    return this.advancedSection.getByLabel(
+      this.translations("bar_chart_race.from"),
+    );
+  }
+
+  public get toYearDropdown() {
+    return this.advancedSection.getByLabel(
+      this.translations("bar_chart_race.to"),
+    );
+  }
+
+  public fromYearOption(year: number) {
+    return this.locator.page().getByRole("menuitem", {
+      name: year.toString(),
+      exact: true,
+    });
+  }
+
+  public toYearOption(year: number) {
+    return this.locator.page().getByRole("menuitem", {
+      name: year.toString(),
+      exact: true,
+    });
+  }
+}
+
+class DataExportTool extends LocatorObject {
+  public downloadCSV = this.locator.getByText(
+    this.translations("common.download_format", { format: "CSV" }),
+  );
+  public downloadJSON = this.locator.getByText(
+    this.translations("common.download_format", { format: "JSON" }),
+  );
+}
+class BarChartRaceTool extends YearRangeFilterTool {
   public get groupByFieldset() {
     return this.locator.locator("fieldset").filter({
       has: this.locator
@@ -78,40 +114,6 @@ class BarChartRaceTool extends LocatorObject {
     });
   }
 
-  public get advancedSection() {
-    return this.locator.locator("details");
-  }
-
-  public get advancedSummary() {
-    return this.advancedSection.locator("summary");
-  }
-
-  public get fromYearDropdown() {
-    return this.advancedSection.getByLabel(
-      this.translations("bar_chart_race.from"),
-    );
-  }
-
-  public get toYearDropdown() {
-    return this.advancedSection.getByLabel(
-      this.translations("bar_chart_race.to"),
-    );
-  }
-
-  public fromYearOption(year: number) {
-    return this.locator.page().getByRole("menuitem", {
-      name: year.toString(),
-      exact: true,
-    });
-  }
-
-  public toYearOption(year: number) {
-    return this.locator.page().getByRole("menuitem", {
-      name: year.toString(),
-      exact: true,
-    });
-  }
-
   public get playButton() {
     return this.locator.getByRole("button", {
       name: this.translations("actions.play"),
@@ -137,12 +139,56 @@ class BarChartRaceTool extends LocatorObject {
   }
 }
 
+class ComparePartiesTool extends YearRangeFilterTool {
+  public get partiesFieldset() {
+    return this.locator.locator("fieldset").filter({
+      has: this.locator
+        .page()
+        .getByText(this.translations("compare_parties.parties"), {
+          exact: true,
+        }),
+    });
+  }
+
+  public get overviewSection() {
+    return this.locator.locator("#sec-compare-overview").locator("..");
+  }
+
+  public get timelineSection() {
+    return this.locator.locator("#sec-compare-timeline").locator("..");
+  }
+
+  public get donorsSection() {
+    return this.locator.locator("#sec-compare-donors").locator("..");
+  }
+
+  public get topDonationsSection() {
+    return this.locator.locator("#sec-compare-top-donations").locator("..");
+  }
+
+  public get overlappingDonorsSection() {
+    return this.locator
+      .locator("#sec-compare-overlapping-donors")
+      .locator("..");
+  }
+
+  public partyButton(short: string) {
+    return this.partiesFieldset.getByRole("button", {
+      name: short,
+    });
+  }
+}
+
 export class Tools extends PageObject {
   public readonly dataExport = new DataExportTool(
     this.page.getByRole("main"),
     this.props,
   );
   public readonly barChartRaceTool = new BarChartRaceTool(
+    this.page.getByRole("main"),
+    this.props,
+  );
+  public readonly comparePartiesTool = new ComparePartiesTool(
     this.page.getByRole("main"),
     this.props,
   );

--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -105,8 +105,65 @@ test.describe("Tools", () => {
         await barChartRaceTool.toYearOption(2021).click();
 
         const url = new URL(page.url());
+        expect(url.searchParams.get("to")).toBe("2021");
+      });
+    });
+  });
+
+  test.describe("Compare parties", () => {
+    test.beforeEach(async ({ page, baseURL }) => {
+      await page.goto(`${baseURL}/germany/tools/compare`);
+    });
+
+    test(`it works`, async ({ page, accessibility, tools }) => {
+      const { comparePartiesTool } = tools;
+
+      await expect(comparePartiesTool.legislativeYearsFieldset).toBeVisible();
+      await accessibility.check();
+
+      await test.step("Clicking legislative year range updates URL", async () => {
+        await comparePartiesTool.legislativeYearButton("2018-2021").click();
+
+        const url = new URL(page.url());
         expect(url.searchParams.get("from")).toBe("2018");
         expect(url.searchParams.get("to")).toBe("2021");
+      });
+
+      await test.step("Clicking individual year updates URL", async () => {
+        await comparePartiesTool.individualYearButton(2020).click();
+
+        const url = new URL(page.url());
+        expect(url.searchParams.get("from")).toBe("2020");
+        expect(url.searchParams.get("to")).toBe("2020");
+      });
+
+      await test.step("Clicking different individual year updates URL", async () => {
+        await comparePartiesTool.individualYearButton(2023).click();
+
+        const url = new URL(page.url());
+        expect(url.searchParams.get("from")).toBe("2023");
+        expect(url.searchParams.get("to")).toBe("2023");
+      });
+
+      await test.step("Opening advanced and selecting range updates URL", async () => {
+        await comparePartiesTool.advancedSummary.click();
+
+        await comparePartiesTool.fromYearDropdown.click();
+        await comparePartiesTool.fromYearOption(2018).click();
+
+        await comparePartiesTool.toYearDropdown.click();
+        await comparePartiesTool.toYearOption(2021).click();
+
+        const url = new URL(page.url());
+        expect(url.searchParams.get("from")).toBe("2018");
+        expect(url.searchParams.get("to")).toBe("2021");
+      });
+
+      await test.step("pick parties to compare", async () => {
+        await comparePartiesTool.partyButton("Volt").click();
+        await expect(comparePartiesTool.overviewSection).toBeHidden();
+        await comparePartiesTool.partyButton("SPD").click();
+        await expect(comparePartiesTool.overviewSection).toBeVisible();
       });
     });
   });

--- a/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars-content.tsx
+++ b/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars-content.tsx
@@ -1,18 +1,11 @@
 "use client";
-import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import { useLocale } from "next-intl";
 import { parseAsString, useQueryState } from "nuqs";
 import { useMemo } from "react";
 
 import { EChartsRacingBars } from "../../../../../components/echarts/echarts-racing-bars";
 import { Button } from "../../../../../components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../../../../../components/ui/dropdown-menu";
-import { cn } from "../../../../../utils/classname";
+import { YearRangeSelector } from "../../../../../components/year-range-selector";
 import {
   type CountryConfig,
   getCountryName,
@@ -31,7 +24,6 @@ export const RacingBarsContent = ({
   allDonations: Donation[];
 }) => {
   const tCountries = useTranslations("countries");
-  const tSearch = useTranslations("search");
   const tBarChartRace = useTranslations("bar_chart_race");
   const locale = useLocale();
 
@@ -97,75 +89,15 @@ export const RacingBarsContent = ({
     });
   }, [allDonations, validSelectedYears, countryConfig.years.length]);
 
-  const handleFromYearChange = (year: string) => {
-    // If new start > current end, push end to new start (or just let disabled attributes handle it)
-    // With disabled attributes, this shouldn't happen, but good safety.
-    if (year > toYear) {
-      void setToYear(year);
-    }
-    void setFromYear(year);
-  };
-
-  const handleToYearChange = (year: string) => {
-    if (year < fromYear) {
-      void setFromYear(year);
-    }
-    void setToYear(year);
-  };
-
   return (
     <div className="flex flex-col gap-4">
-      <fieldset className="m-0 border-0 p-0">
-        <legend className="mb-2 text-sm font-medium">
-          {tSearch("legislative_years")}
-        </legend>
-        <div className="flex flex-wrap gap-2">
-          {countryConfig.legislativeYears.map((years) => {
-            const start = years[0];
-            const end = years[years.length - 1];
-            const label = `${start}-${end}`;
-            const isActive = fromYear === start && toYear === end;
-
-            return (
-              <Button
-                key={label}
-                variant={isActive ? "default" : "outline"}
-                onClick={() => {
-                  setFromYear(start);
-                  setToYear(end);
-                }}
-              >
-                {label}
-              </Button>
-            );
-          })}
-        </div>
-      </fieldset>
-
-      {/* Individual year buttons */}
-      <fieldset className="m-0 border-0 p-0">
-        <legend className="mb-2 text-sm font-medium">
-          {tBarChartRace("individual_years")}
-        </legend>
-        <div className="flex flex-wrap gap-2">
-          {countryConfig.years.map((year) => {
-            const isActive = fromYear === year && toYear === year;
-            return (
-              <Button
-                key={year}
-                variant={isActive ? "default" : "outline"}
-                size="sm"
-                onClick={() => {
-                  setFromYear(year);
-                  setToYear(year);
-                }}
-              >
-                {year}
-              </Button>
-            );
-          })}
-        </div>
-      </fieldset>
+      <YearRangeSelector
+        countryConfig={countryConfig}
+        fromYear={fromYear}
+        toYear={toYear}
+        setFromYear={setFromYear}
+        setToYear={setToYear}
+      />
 
       <fieldset className="m-0 border-0 p-0">
         <legend className="mb-2 text-sm font-medium">
@@ -234,80 +166,6 @@ export const RacingBarsContent = ({
           ))}
         </div>
       </fieldset>
-
-      {/* Advanced year range selection */}
-      <details className="group">
-        <summary className="text-accent-foreground hover:text-foreground cursor-pointer text-sm font-medium">
-          {tBarChartRace("custom_range")}
-        </summary>
-        <div className="mt-2 flex flex-row items-center gap-2">
-          <label htmlFor="from-year-select" className="text-sm font-medium">
-            {tBarChartRace("from")}
-          </label>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              id="from-year-select"
-              render={
-                <Button variant="outline" className="w-32 justify-between" />
-              }
-            >
-              {fromYear}
-              <ChevronDownIcon className="size-4 opacity-50" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="h-64">
-              {countryConfig.years.map((year) => (
-                <DropdownMenuItem
-                  key={year}
-                  onClick={() => handleFromYearChange(year)}
-                  disabled={year > toYear}
-                  className={cn(
-                    "flex justify-between",
-                    year === fromYear &&
-                      "bg-accent text-accent-foreground font-bold",
-                  )}
-                >
-                  {year}
-                  {year === fromYear && <CheckIcon className="size-4" />}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <span className="text-muted-foreground">-</span>
-          <label htmlFor="to-year-select" className="text-sm font-medium">
-            {tBarChartRace("to")}
-          </label>
-
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              id="to-year-select"
-              render={
-                <Button variant="outline" className="w-32 justify-between" />
-              }
-            >
-              {toYear}
-              <ChevronDownIcon className="size-4 opacity-50" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="h-64">
-              {countryConfig.years.map((year) => (
-                <DropdownMenuItem
-                  key={year}
-                  onClick={() => handleToYearChange(year)}
-                  disabled={year < fromYear}
-                  className={cn(
-                    "flex justify-between",
-                    year === toYear &&
-                      "bg-accent text-accent-foreground font-bold",
-                  )}
-                >
-                  {year}
-                  {year === toYear && <CheckIcon className="size-4" />}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </details>
 
       {filteredDonations.length ? (
         <EChartsRacingBars

--- a/src/app/[locale]/[country]/tools/compare/page.tsx
+++ b/src/app/[locale]/[country]/tools/compare/page.tsx
@@ -1,0 +1,70 @@
+import { notFound } from "next/navigation";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+
+import type { Metadata } from "next";
+
+import { Article } from "@/components/layout/article";
+import { PartyComparison } from "@/components/party-comparison";
+import { COUNTRIES } from "@/utils/countries";
+import { getCountryConfig } from "@/utils/data/get-country-config";
+import { LOCALES } from "@/utils/locales";
+import { generateAlternates } from "@/utils/meta";
+import { notFoundMetadata } from "@/utils/not-found-metadata";
+import { isValidCountry, isValidLocale } from "@/utils/validate";
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  return [...COUNTRIES].flatMap((country) =>
+    LOCALES.map((locale) => ({ locale, country })),
+  );
+}
+
+export async function generateMetadata(
+  props: PageProps<"/[locale]/[country]/tools/compare">,
+): Promise<Metadata> {
+  const params = await props.params;
+
+  if (!isValidLocale(params.locale)) return notFoundMetadata;
+  if (!isValidCountry(params.country)) return notFoundMetadata;
+  setRequestLocale(params.locale);
+
+  const { country } = params;
+
+  const tCompareParties = await getTranslations({
+    locale: params.locale,
+    namespace: "compare_parties_page",
+  });
+
+  return {
+    title: `${tCompareParties("title")} | DonationWatch`,
+    alternates: generateAlternates(`${country}/tools/compare`),
+  };
+}
+
+export default async function Page(
+  props: PageProps<"/[locale]/[country]/tools/compare">,
+) {
+  const params = await props.params;
+
+  if (!isValidLocale(params.locale)) return notFound();
+  if (!isValidCountry(params.country)) return notFound();
+  setRequestLocale(params.locale);
+
+  const { country } = params;
+
+  const [countryConfig, tCompareParties] = await Promise.all([
+    getCountryConfig(country),
+    getTranslations({
+      locale: params.locale,
+      namespace: "compare_parties_page",
+    }),
+  ]);
+
+  return (
+    <Article title={tCompareParties("title")}>
+      <p className="mb-8 max-w-prose">{tCompareParties("description")}</p>
+      <PartyComparison countryConfig={countryConfig} />
+    </Article>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -108,6 +108,14 @@ export default async function sitemap(props: {
                 url: `${BASE_URL}/${locale}/${country}/tools/data`,
                 lastModified,
               },
+              {
+                url: `${BASE_URL}/${locale}/${country}/tools/bar-chart-race`,
+                lastModified,
+              },
+              {
+                url: `${BASE_URL}/${locale}/${country}/tools/compare`,
+                lastModified,
+              },
               config.parties.flatMap((party) => {
                 const partiesBaseUrl = `${BASE_URL}/${locale}/${country}/party/${party.id}`;
                 const lastDonation = lastPartyStatsDonation(

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChartBarStacked,
   ChevronRight,
   FileSpreadsheet,
+  Scale,
   UserRound,
   Vote,
 } from "lucide-react";
@@ -137,7 +138,7 @@ export function AppSidebar({
                           ))}
                         {!showAllParties &&
                           countryConfig.parties.length >
-                            SIDENAV_PARTIES_VISIBLE && (
+                          SIDENAV_PARTIES_VISIBLE && (
                             <SidebarMenuSubItem>
                               <SidebarMenuButton
                                 onClick={() => setShowAllParties(true)}
@@ -153,7 +154,7 @@ export function AppSidebar({
                           )}
                         {showAllParties &&
                           countryConfig.parties.length >
-                            SIDENAV_PARTIES_VISIBLE && (
+                          SIDENAV_PARTIES_VISIBLE && (
                             <SidebarMenuSubItem>
                               <SidebarMenuButton
                                 onClick={() => setShowAllParties(false)}
@@ -233,6 +234,18 @@ export function AppSidebar({
                     </SidebarActiveMenuButton>
                   </SidebarMenuItem>
                 ) : null}
+                <SidebarMenuItem>
+                  <SidebarActiveMenuButton
+                    activeHref={`/${locale}/${countryConfig.id}/tools/compare`}
+                    href={`/${locale}/${countryConfig.id}/tools/compare`}
+                    asChild
+                  >
+                    <a href={`/${locale}/${countryConfig.id}/tools/compare`}>
+                      <Scale />
+                      <span>Compare Parties</span>
+                    </a>
+                  </SidebarActiveMenuButton>
+                </SidebarMenuItem>
               </SidebarMenu>
             </SidebarGroup>
           </>

--- a/src/components/party-comparison.tsx
+++ b/src/components/party-comparison.tsx
@@ -1,0 +1,1333 @@
+"use client";
+
+import { useQueries } from "@tanstack/react-query";
+import { Trophy } from "lucide-react";
+import { useLocale } from "next-intl";
+import { parseAsArrayOf, parseAsString, useQueryState } from "nuqs";
+import { useMemo } from "react";
+
+import { DonorLink } from "./donor-link";
+import { ArticleSection } from "./layout/article";
+import Loading from "./loading";
+import { PartyDot } from "./party-dot";
+import { Button } from "./ui/button";
+import { YearRangeSelector } from "./year-range-selector";
+import { firstItem, lastItem } from "../utils/array";
+import { QUERY_PARAM_BUILD_TS } from "../utils/config";
+import { donationYear } from "../utils/date";
+import {
+  formatCompactCountryCurrency,
+  formatCountryCurrency,
+  formatNumber,
+  formatPercentFormat,
+  formatYearsRange,
+} from "../utils/formatter";
+import { getBuild } from "../utils/loader/build";
+import { DonationField, DonorType } from "../utils/types";
+
+import type { CountryConfig } from "../utils/countries";
+import type { Donation, Party, ReceiverId } from "../utils/types";
+import type { DonationsDocumentWithoutDonorIds } from "@/lib/api/donations-document";
+import type { RootTranslator } from "@/utils/translator";
+import type { UseQueryOptions } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
+import { donationDocumentToDonations } from "@/lib/api/donations-document";
+import { partyColor } from "@/utils/color";
+
+const MAX_PARTY_SELECTION = 4;
+const OVERLAP_MAX = 25;
+const NO_DATA_TEXT = "-";
+
+interface PartyStats {
+  party: Party;
+  donations: Donation[];
+  totalSum: number;
+  count: number;
+  average: number;
+  median: number;
+  uniqueDonors: Set<string>;
+  largestDonation: Donation | undefined;
+  topDonor: { name: string; sum: number } | undefined;
+  mostFrequentDonor: { name: string; count: number } | undefined;
+  firstYear: string;
+  lastYear: string;
+  mostActiveYear: { year: string; sum: number } | undefined;
+  yearWithMostDonations: { year: string; count: number } | undefined;
+  topDonors: { name: string; sum: number }[];
+  donorTypeBreakdown: {
+    type: DonorType;
+    label: string;
+    sum: number;
+    count: number;
+    percentage: number;
+  }[];
+}
+
+function computePartyStats(
+  party: Party,
+  donations: Donation[],
+  t: RootTranslator,
+): PartyStats {
+  const partyDonations = donations.filter(
+    (d) => d[DonationField.Receiver] === party.id,
+  );
+
+  let totalSum = 0;
+  const donorSums: Record<string, number> = {};
+  const donorCounts: Record<string, number> = {};
+  const yearSums: Record<string, number> = {};
+  const yearCounts: Record<string, number> = {};
+  const uniqueDonors = new Set<string>();
+  let amounts: number[] = [];
+
+  let largestDonation: Donation | undefined;
+
+  for (const donation of partyDonations) {
+    const amount = donation[DonationField.Amount];
+    const donor = donation[DonationField.DonorName];
+    const year = donationYear(donation);
+
+    totalSum += amount;
+    amounts.push(amount);
+    uniqueDonors.add(donor);
+
+    donorSums[donor] = (donorSums[donor] ?? 0) + amount;
+    donorCounts[donor] = (donorCounts[donor] ?? 0) + 1;
+    yearSums[year] = (yearSums[year] ?? 0) + amount;
+    yearCounts[year] = (yearCounts[year] ?? 0) + 1;
+
+    if (!largestDonation || amount > largestDonation[DonationField.Amount]) {
+      largestDonation = donation;
+    }
+  }
+
+  // Median
+  amounts = amounts.toSorted((a, b) => a - b);
+
+  const median =
+    amounts.length === 0
+      ? 0
+      : amounts.length % 2 === 1
+        ? amounts[Math.floor(amounts.length / 2)]
+        : (amounts[Math.floor(amounts.length / 2) - 1] +
+            amounts[Math.floor(amounts.length / 2)]) /
+          2;
+
+  // Top donor by sum
+  const topDonorEntry = Object.entries(donorSums).toSorted(
+    (a, b) => b[1] - a[1],
+  )[0];
+  const topDonor = topDonorEntry
+    ? { name: topDonorEntry[0], sum: topDonorEntry[1] }
+    : undefined;
+
+  // Top 3 donors
+  const topDonors = Object.entries(donorSums)
+    .toSorted((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([name, sum]) => ({ name, sum }));
+
+  // Most frequent donor
+  const maxCount = Math.max(0, ...Object.values(donorCounts));
+  const frequentDonors = Object.entries(donorCounts).filter(
+    ([, c]) => c === maxCount,
+  );
+  const mostFrequentDonor =
+    frequentDonors.length === 1
+      ? { name: frequentDonors[0][0], count: frequentDonors[0][1] }
+      : undefined;
+
+  // Year stats
+  const years = Object.keys(yearSums).toSorted();
+  const firstYear = years[0] ?? "";
+  const lastYear = years.at(-1) ?? "";
+
+  const mostActiveYearEntry = Object.entries(yearSums).toSorted(
+    (a, b) => b[1] - a[1],
+  )[0];
+  const mostActiveYear = mostActiveYearEntry
+    ? { year: mostActiveYearEntry[0], sum: mostActiveYearEntry[1] }
+    : undefined;
+
+  const yearWithMostDonationsEntry = Object.entries(yearCounts).toSorted(
+    (a, b) => b[1] - a[1],
+  )[0];
+  const yearWithMostDonations = yearWithMostDonationsEntry
+    ? {
+        year: yearWithMostDonationsEntry[0],
+        count: yearWithMostDonationsEntry[1],
+      }
+    : undefined;
+
+  // Donor type breakdown
+  const typeSums: Partial<Record<DonorType, { sum: number; count: number }>> =
+    {};
+  for (const donation of partyDonations) {
+    const dt = donation[DonationField.DonorType] ?? DonorType.Other;
+    typeSums[dt] ??= { sum: 0, count: 0 };
+    typeSums[dt]!.sum += donation[DonationField.Amount];
+    typeSums[dt]!.count++;
+  }
+  const donorTypeBreakdown = Object.entries(typeSums)
+    .map(([type, stats]) => ({
+      type: Number(type) as DonorType,
+      label: t(`donor_type.${Number(type) as DonorType}`),
+      sum: stats.sum,
+      count: stats.count,
+      percentage: totalSum > 0 ? stats.sum / totalSum : 0,
+    }))
+    .toSorted((a, b) => b.sum - a.sum);
+
+  return {
+    party,
+    donations: partyDonations,
+    totalSum,
+    count: partyDonations.length,
+    average: partyDonations.length > 0 ? totalSum / partyDonations.length : 0,
+    median,
+    uniqueDonors,
+    largestDonation,
+    topDonor,
+    mostFrequentDonor,
+    firstYear,
+    lastYear,
+    mostActiveYear,
+    yearWithMostDonations,
+    topDonors,
+    donorTypeBreakdown,
+  };
+}
+
+interface OverlappingDonor {
+  name: string;
+  /** Per-party stats for this donor, keyed by ReceiverId */
+  perParty: Record<ReceiverId, { sum: number; count: number }>;
+  partyCount: number;
+  totalSum: number;
+}
+
+function computeOverlappingDonors(
+  statsArray: PartyStats[],
+): OverlappingDonor[] {
+  const donorData: Record<
+    string,
+    Record<ReceiverId, { sum: number; count: number }>
+  > = {};
+
+  for (const stats of statsArray) {
+    for (const donation of stats.donations) {
+      const donor = donation[DonationField.DonorName];
+      const amount = donation[DonationField.Amount];
+      donorData[donor] ??= {};
+      donorData[donor][stats.party.id] ??= { sum: 0, count: 0 };
+      donorData[donor][stats.party.id].sum += amount;
+      donorData[donor][stats.party.id].count += 1;
+    }
+  }
+
+  return Object.entries(donorData)
+    .filter(([, perParty]) => Object.keys(perParty).length >= 2)
+    .map(([name, perParty]) => {
+      const totalSum = Object.values(perParty).reduce(
+        (acc, d) => acc + d.sum,
+        0,
+      );
+      return {
+        name,
+        perParty,
+        partyCount: Object.keys(perParty).length,
+        totalSum,
+      };
+    })
+    .toSorted((a, b) => b.totalSum - a.totalSum);
+}
+
+/**
+ * Finds the party with the highest value for a given numeric extractor.
+ * Returns the ReceiverId of the winner, or undefined if tied / no data.
+ */
+function findWinner(
+  allStats: PartyStats[],
+  extractor: (s: PartyStats) => number,
+): ReceiverId | undefined {
+  if (allStats.length < 2) return undefined;
+  let best: PartyStats | undefined;
+  let bestValue = -Infinity;
+  let tied = false;
+
+  for (const stats of allStats) {
+    const value = extractor(stats);
+    if (value > bestValue) {
+      best = stats;
+      bestValue = value;
+      tied = false;
+    } else if (value === bestValue) {
+      tied = true;
+    }
+  }
+
+  if (tied || !best) return undefined;
+  return best.party.id;
+}
+
+const jsonFetcher = <T = unknown,>(input: RequestInfo): Promise<T> =>
+  fetch(input).then((res) => {
+    if (!res.ok) throw new Error(`Network response was not ok: ${res.status}`);
+    return res.json();
+  });
+
+/** A single row definition for the comparison table */
+interface ComparisonRow {
+  label: string;
+  values: (stats: PartyStats) => React.ReactNode;
+  winner?: ReceiverId;
+}
+
+export const PartyComparison = ({
+  countryConfig,
+}: {
+  countryConfig: CountryConfig;
+}) => {
+  const t = useTranslations();
+  const tCompareParties = useTranslations("compare_parties");
+  const tData = useTranslations("data");
+  const locale = useLocale();
+  const [partiesParam, setPartiesParam] = useQueryState(
+    "parties",
+    parseAsArrayOf(parseAsString).withDefault([]),
+  );
+  const selectedPartyIds = new Set(partiesParam as ReceiverId[]);
+
+  // Year filter state
+  const lastLegislativeYear = lastItem(countryConfig.legislativeYears);
+  const [fromYear, setFromYear] = useQueryState(
+    "from",
+    parseAsString.withDefault(firstItem(lastLegislativeYear)),
+  );
+  const [toYear, setToYear] = useQueryState(
+    "to",
+    parseAsString.withDefault(lastItem(lastLegislativeYear)),
+  );
+  const isAllYears =
+    fromYear === countryConfig.years[0] &&
+    toYear === countryConfig.years[countryConfig.years.length - 1];
+
+  const build = getBuild(countryConfig.id).t;
+
+  const selectedParties = countryConfig.parties.filter((p) =>
+    selectedPartyIds.has(p.id),
+  );
+
+  const results = useQueries<UseQueryOptions<Donation[]>[]>({
+    queries: selectedParties.map((party) => ({
+      queryKey: [countryConfig.id, "donations", "by-party", party.id],
+      queryFn: () =>
+        jsonFetcher<DonationsDocumentWithoutDonorIds>(
+          `/data/${countryConfig.id}/donations/by-party/${party.id}.json?${QUERY_PARAM_BUILD_TS}=${build}`,
+        ).then((doc) => donationDocumentToDonations(doc)),
+    })),
+  });
+
+  const isLoading = results.some((r) => r.isLoading);
+  const hasError = results.some((r) => r.error);
+
+  const toggleParty = (partyId: ReceiverId) => {
+    setPartiesParam((prev) => {
+      const next = new Set(prev);
+      if (next.has(partyId)) {
+        next.delete(partyId);
+      } else {
+        if (next.size >= MAX_PARTY_SELECTION) return Array.from(next);
+        next.add(partyId);
+      }
+      return Array.from(next);
+    });
+  };
+
+  // Filter donations by selected year range
+  const filterDonationsByYear = useMemo(() => {
+    if (isAllYears) return (donations: Donation[]) => donations;
+    return (donations: Donation[]) =>
+      donations.filter((d) => {
+        const year = donationYear(d);
+        return year >= fromYear && year <= toYear;
+      });
+  }, [fromYear, toYear, isAllYears]);
+
+  // Compute stats for loaded parties
+  const allStats: PartyStats[] = [];
+  for (let i = 0; i < selectedParties.length; i++) {
+    const result = results[i];
+    if (result?.data) {
+      allStats.push(
+        computePartyStats(
+          selectedParties[i],
+          filterDonationsByYear(result.data),
+          t,
+        ),
+      );
+    }
+  }
+
+  const overlappingDonors =
+    allStats.length >= 2 ? computeOverlappingDonors(allStats) : [];
+  const canCompare = selectedPartyIds.size >= 2;
+
+  // Winner calculations
+  const winners = {
+    totalSum: findWinner(allStats, (s) => s.totalSum),
+    count: findWinner(allStats, (s) => s.count),
+    average: findWinner(allStats, (s) => s.average),
+    median: findWinner(allStats, (s) => s.median),
+    uniqueDonors: findWinner(allStats, (s) => s.uniqueDonors.size),
+    topDonorSum: findWinner(allStats, (s) => s.topDonor?.sum ?? 0),
+    mostFrequentCount: findWinner(
+      allStats,
+      (s) => s.mostFrequentDonor?.count ?? 0,
+    ),
+    largestDonation: findWinner(
+      allStats,
+      (s) => s.largestDonation?.[DonationField.Amount] ?? 0,
+    ),
+    mostActiveYearSum: findWinner(allStats, (s) => s.mostActiveYear?.sum ?? 0),
+    yearWithMostDonationsCount: findWinner(
+      allStats,
+      (s) => s.yearWithMostDonations?.count ?? 0,
+    ),
+  };
+
+  // Row definitions per section
+  const overviewRows: ComparisonRow[] = [
+    {
+      label: tCompareParties("stats.sum"),
+      values: (s) => formatCountryCurrency(locale, s.totalSum, countryConfig),
+      winner: winners.totalSum,
+    },
+    {
+      label: tCompareParties("stats.count"),
+      values: (s) => formatNumber(locale, s.count),
+      winner: winners.count,
+    },
+    {
+      label: tCompareParties("stats.avg"),
+      values: (s) => formatCountryCurrency(locale, s.average, countryConfig),
+      winner: winners.average,
+    },
+    {
+      label: tCompareParties("stats.median"),
+      values: (s) => formatCountryCurrency(locale, s.median, countryConfig),
+      winner: winners.median,
+    },
+  ];
+
+  const timelineRows: ComparisonRow[] = [
+    {
+      label: tCompareParties("stats.first_year"),
+      values: (s) => s.firstYear || NO_DATA_TEXT,
+    },
+    {
+      label: tCompareParties("stats.last_year"),
+      values: (s) => s.lastYear || NO_DATA_TEXT,
+    },
+    {
+      label: tCompareParties("stats.active_year_sum"),
+      values: (s) =>
+        s.mostActiveYear ? (
+          <TwoLineCell
+            primary={s.mostActiveYear.year}
+            secondary={formatCountryCurrency(
+              locale,
+              s.mostActiveYear.sum,
+              countryConfig,
+            )}
+          />
+        ) : (
+          NO_DATA_TEXT
+        ),
+      winner: winners.mostActiveYearSum,
+    },
+    {
+      label: tCompareParties("stats.active_year_count"),
+      values: (s) =>
+        s.yearWithMostDonations ? (
+          <TwoLineCell
+            primary={s.yearWithMostDonations.year}
+            secondary={tCompareParties("n_donations", {
+              count: formatNumber(locale, s.yearWithMostDonations.count),
+            })}
+          />
+        ) : (
+          NO_DATA_TEXT
+        ),
+      winner: winners.yearWithMostDonationsCount,
+    },
+  ];
+
+  const donorRows: ComparisonRow[] = [
+    {
+      label: tCompareParties("stats.unique_donors"),
+      values: (s) => formatNumber(locale, s.uniqueDonors.size),
+      winner: winners.uniqueDonors,
+    },
+    {
+      label: tCompareParties("stats.top_donor"),
+      values: (s) =>
+        s.topDonor ? (
+          <TwoLineCell
+            primary={
+              <DonorLink country={countryConfig} donor={s.topDonor.name} />
+            }
+            secondary={formatCountryCurrency(
+              locale,
+              s.topDonor.sum,
+              countryConfig,
+            )}
+          />
+        ) : (
+          NO_DATA_TEXT
+        ),
+      winner: winners.topDonorSum,
+    },
+    {
+      label: tCompareParties("stats.frequent_donor"),
+      values: (s) =>
+        s.mostFrequentDonor ? (
+          <TwoLineCell
+            primary={
+              <DonorLink
+                country={countryConfig}
+                donor={s.mostFrequentDonor.name}
+              />
+            }
+            secondary={tCompareParties("n_donations", {
+              count: formatNumber(locale, s.mostFrequentDonor.count),
+            })}
+          />
+        ) : (
+          NO_DATA_TEXT
+        ),
+      winner: winners.mostFrequentCount,
+    },
+  ];
+
+  const topDonationRows: ComparisonRow[] = [
+    {
+      label: tCompareParties("stats.biggest_donation"),
+      values: (s) =>
+        s.largestDonation ? (
+          <TwoLineCell
+            primary={formatCountryCurrency(
+              locale,
+              s.largestDonation[DonationField.Amount],
+              countryConfig,
+            )}
+            secondary={
+              <DonorLink
+                country={countryConfig}
+                donor={s.largestDonation[DonationField.DonorName]}
+              />
+            }
+          />
+        ) : (
+          NO_DATA_TEXT
+        ),
+      winner: winners.largestDonation,
+    },
+  ];
+
+  return (
+    <div>
+      {/* Party Selector */}
+      <fieldset className="m-0 mb-6 border-0 p-0">
+        <legend className="mb-2 text-sm font-medium">
+          {tCompareParties("parties")}
+        </legend>
+        <div className="flex flex-wrap gap-2">
+          {countryConfig.parties.map((party) => {
+            const isSelected = selectedPartyIds.has(party.id);
+            return (
+              <Button
+                variant={isSelected ? "default" : "outline"}
+                key={party.id}
+                onClick={() => toggleParty(party.id)}
+                disabled={
+                  !isSelected && selectedPartyIds.size >= MAX_PARTY_SELECTION
+                }
+              >
+                <PartyDot party={party.id} country={countryConfig} />
+              </Button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Year Filter */}
+      <div className="mb-8">
+        <YearRangeSelector
+          countryConfig={countryConfig}
+          fromYear={fromYear}
+          toYear={toYear}
+          setFromYear={setFromYear}
+          setToYear={setToYear}
+          showAllYears
+        />
+      </div>
+
+      {!canCompare && <p>{tCompareParties("min_select")}</p>}
+
+      {canCompare && isLoading && <Loading />}
+      {canCompare && hasError && <p>{tData("error")}</p>}
+
+      {canCompare && !isLoading && !hasError && allStats.length >= 2 && (
+        <>
+          {/* Sticky summary header */}
+          <div className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 -mx-4 mb-4 border-b border-gray-200 px-4 py-3 backdrop-blur md:h-[72px] dark:border-gray-700">
+            <div className="flex items-center justify-between gap-x-4 gap-y-1 pb-1 text-sm">
+              <div className="grow overflow-hidden">
+                <div className="mb-1 text-xs font-medium">
+                  {tCompareParties("comparing")}
+                </div>
+                <div className="hidden items-center gap-2 overflow-hidden md:flex">
+                  {allStats.map((s) => (
+                    <PartyDot
+                      className={"overflow-hidden"}
+                      nameClassName={"truncate"}
+                      key={s.party.id}
+                      party={s.party.id}
+                      country={countryConfig}
+                    />
+                  ))}
+                </div>
+                <div className="md:hidden">
+                  {allStats.length} {tCompareParties("parties")}
+                </div>
+              </div>
+              <div className="shrink-0 font-medium">
+                <div className="mb-1 text-end text-xs font-medium">
+                  {tCompareParties("years")}
+                </div>
+                <div>{formatYearsRange([fromYear, toYear])}</div>
+              </div>
+            </div>
+          </div>
+
+          <ArticleSection
+            title={tCompareParties("overview.title")}
+            id="sec-compare-overview"
+          >
+            <p className="text-muted-foreground mt-1 mb-4 text-sm">
+              {tCompareParties("overview.description")}
+            </p>
+            <ComparisonTable
+              stats={allStats}
+              rows={overviewRows}
+              countryConfig={countryConfig}
+            />
+          </ArticleSection>
+
+          {fromYear === toYear ? null : (
+            <ArticleSection
+              title={tCompareParties("timeline.title")}
+              id="sec-compare-timeline"
+            >
+              <p className="text-muted-foreground mt-1 mb-4 text-sm">
+                {tCompareParties("overview.description")}
+              </p>
+              <ComparisonTable
+                stats={allStats}
+                rows={timelineRows}
+                countryConfig={countryConfig}
+              />
+            </ArticleSection>
+          )}
+
+          <ArticleSection
+            title={tCompareParties("top_donations.title")}
+            id="sec-compare-top-donations"
+          >
+            <p className="text-muted-foreground mt-1 mb-4 text-sm">
+              {tCompareParties("top_donations.description")}
+            </p>
+            <ComparisonTable
+              stats={allStats}
+              rows={topDonationRows}
+              countryConfig={countryConfig}
+            />
+
+            {/* Top 3 Donors per party */}
+            <div className="mt-6">
+              <div className="w-full text-sm">
+                {/* Desktop/Tablet View */}
+                <div className="hidden md:block">
+                  <table className="w-full table-fixed text-sm">
+                    <thead>
+                      <tr className="border-b border-gray-200 dark:border-gray-700">
+                        <th className="bg-background text-muted-foreground sticky top-[72px] left-0 z-20 w-48 px-4 py-3 text-left text-sm font-medium">
+                          {tCompareParties("top_3_donors")}
+                        </th>
+                        {allStats.map((s) => (
+                          <th
+                            key={s.party.id}
+                            className="bg-background sticky top-[72px] z-10 px-4 py-3"
+                          >
+                            <PartyHeader
+                              party={s.party}
+                              country={countryConfig}
+                            />
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {[0, 1, 2].map((rank) => (
+                        <tr
+                          key={rank}
+                          className="border-b border-gray-100 dark:border-gray-800"
+                        >
+                          <td className="bg-background text-muted-foreground sticky left-0 px-4 py-2 text-sm">
+                            #{rank + 1}
+                          </td>
+                          {allStats.map((stats) => {
+                            const donor = stats.topDonors[rank];
+                            return (
+                              <td
+                                key={stats.party.id}
+                                className="px-4 py-2 text-right"
+                              >
+                                {donor ? (
+                                  <div>
+                                    <div className="truncate font-medium">
+                                      <DonorLink
+                                        country={countryConfig}
+                                        donor={donor.name}
+                                      />
+                                    </div>
+                                    <div className="text-muted-foreground text-xs tabular-nums">
+                                      {formatCountryCurrency(
+                                        locale,
+                                        donor.sum,
+                                        countryConfig,
+                                      )}
+                                    </div>
+                                  </div>
+                                ) : (
+                                  NO_DATA_TEXT
+                                )}
+                              </td>
+                            );
+                          })}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Mobile View */}
+                <div className="grid gap-4 md:hidden">
+                  {[0, 1, 2].map((rank) => {
+                    const hasAnyDonor = allStats.some((s) => s.topDonors[rank]);
+                    if (!hasAnyDonor) return null;
+
+                    return (
+                      <div key={rank} className="card min-w-0">
+                        <h4 className="border-b border-gray-100 pb-2 text-sm font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                          #{rank + 1}
+                        </h4>
+                        <div className="mt-3 grid gap-4">
+                          {allStats.map((stats) => {
+                            const donor = stats.topDonors[rank];
+                            return (
+                              <div
+                                key={stats.party.id}
+                                className="flex min-w-0 gap-3"
+                              >
+                                <div
+                                  className="mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full"
+                                  style={{
+                                    backgroundColor: partyColor(
+                                      stats.party.id,
+                                      countryConfig,
+                                    ),
+                                  }}
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <div className="text-muted-foreground mb-1 text-xs font-semibold">
+                                    {stats.party.short}
+                                  </div>
+                                  {donor ? (
+                                    <>
+                                      <div className="truncate font-medium">
+                                        <DonorLink
+                                          country={countryConfig}
+                                          donor={donor.name}
+                                        />
+                                      </div>
+                                      <div className="text-muted-foreground text-xs font-medium tabular-nums">
+                                        {formatCountryCurrency(
+                                          locale,
+                                          donor.sum,
+                                          countryConfig,
+                                        )}
+                                      </div>
+                                    </>
+                                  ) : (
+                                    <div className="text-muted-foreground">
+                                      {NO_DATA_TEXT}
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </ArticleSection>
+
+          {countryConfig.hasDonorType && (
+            <ArticleSection
+              title={tCompareParties("donor_types.title")}
+              id="sec-compare-donor-types"
+            >
+              <p className="text-muted-foreground mt-1 mb-4 text-sm">
+                {tCompareParties("donor_types.description")}
+              </p>
+              <ComparisonTable
+                stats={allStats}
+                rows={[
+                  {
+                    label: tCompareParties("donor_types.biggest_donor_type"),
+                    values: (s) => {
+                      const top = s.donorTypeBreakdown[0];
+                      return top ? (
+                        <TwoLineCell
+                          primary={top.label}
+                          secondary={`${formatCountryCurrency(
+                            locale,
+                            top.sum,
+                            countryConfig,
+                          )} · ${formatPercentFormat(locale, top.percentage)}`}
+                        />
+                      ) : (
+                        NO_DATA_TEXT
+                      );
+                    },
+                  },
+                ]}
+                countryConfig={countryConfig}
+              />
+
+              {/* Donor type distribution */}
+              <div className="mt-6 w-full text-sm">
+                {(() => {
+                  // Collect all donor types across parties
+                  const allTypes = new Set<DonorType>();
+                  for (const s of allStats) {
+                    for (const b of s.donorTypeBreakdown) {
+                      allTypes.add(b.type);
+                    }
+                  }
+                  // Sort by label
+                  const sortedTypes = [...allTypes].toSorted((a, b) =>
+                    t(`donor_type.${a}`).localeCompare(t(`donor_type.${b}`)),
+                  );
+
+                  return (
+                    <>
+                      {/* Desktop/Tablet View */}
+                      <div className="hidden md:block">
+                        <table className="w-full table-fixed text-sm">
+                          <thead>
+                            <tr className="border-b border-gray-200 dark:border-gray-700">
+                              <th className="bg-background text-muted-foreground sticky top-[72px] left-0 z-20 w-48 px-4 py-3 text-left text-sm font-medium">
+                                {tCompareParties("donor_type")}
+                              </th>
+                              {allStats.map((s) => (
+                                <th
+                                  key={s.party.id}
+                                  className="bg-background sticky top-[72px] z-10 px-4 py-3"
+                                >
+                                  <PartyHeader
+                                    party={s.party}
+                                    country={countryConfig}
+                                  />
+                                </th>
+                              ))}
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {sortedTypes.map((dt) => (
+                              <tr
+                                key={dt}
+                                className="border-b border-gray-100 dark:border-gray-800"
+                              >
+                                <td className="bg-background text-muted-foreground sticky left-0 w-48 px-4 py-2 text-sm whitespace-nowrap">
+                                  {t(`donor_type.${dt}`)}
+                                </td>
+                                {allStats.map((s) => {
+                                  const entry = s.donorTypeBreakdown.find(
+                                    (b) => b.type === dt,
+                                  );
+                                  return (
+                                    <td
+                                      key={s.party.id}
+                                      className="px-4 py-2 text-right tabular-nums"
+                                    >
+                                      {entry ? (
+                                        <TwoLineCell
+                                          primary={formatPercentFormat(
+                                            locale,
+                                            entry.percentage,
+                                          )}
+                                          secondary={formatCountryCurrency(
+                                            locale,
+                                            entry.sum,
+                                            countryConfig,
+                                          )}
+                                        />
+                                      ) : (
+                                        NO_DATA_TEXT
+                                      )}
+                                    </td>
+                                  );
+                                })}
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+
+                      {/* Mobile View */}
+                      <div className="grid gap-4 md:hidden">
+                        {sortedTypes.map((dt) => (
+                          <div key={dt} className="card min-w-0">
+                            <h4 className="border-b border-gray-100 pb-2 text-sm font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                              {t(`donor_type.${dt}`)}
+                            </h4>
+                            <div className="mt-3 grid gap-4">
+                              {allStats.map((stats) => {
+                                const entry = stats.donorTypeBreakdown.find(
+                                  (b) => b.type === dt,
+                                );
+                                return (
+                                  <div
+                                    key={stats.party.id}
+                                    className="flex gap-3"
+                                  >
+                                    <div
+                                      className="mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full"
+                                      style={{
+                                        backgroundColor: partyColor(
+                                          stats.party.id,
+                                          countryConfig,
+                                        ),
+                                      }}
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                      <div className="text-muted-foreground mb-1 text-xs font-semibold">
+                                        {stats.party.short}
+                                      </div>
+                                      <div className="font-medium tabular-nums">
+                                        {entry ? (
+                                          <TwoLineCell
+                                            primary={formatPercentFormat(
+                                              locale,
+                                              entry.percentage,
+                                            )}
+                                            secondary={formatCountryCurrency(
+                                              locale,
+                                              entry.sum,
+                                              countryConfig,
+                                            )}
+                                          />
+                                        ) : (
+                                          <span className="text-muted-foreground">
+                                            {NO_DATA_TEXT}
+                                          </span>
+                                        )}
+                                      </div>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  );
+                })()}
+              </div>
+            </ArticleSection>
+          )}
+
+          <ArticleSection
+            title={tCompareParties("donors.title")}
+            id="sec-compare-donors"
+          >
+            <p className="text-muted-foreground mt-1 mb-4 text-sm">
+              {tCompareParties("donors.description")}
+            </p>
+            <ComparisonTable
+              stats={allStats}
+              rows={donorRows}
+              countryConfig={countryConfig}
+            />
+
+            {/* Overlapping Donors */}
+            {overlappingDonors.length > 0 && (
+              <div className="mt-6">
+                <h3 className="mb-3 text-lg font-semibold">
+                  {tCompareParties("overlapping.title", {
+                    count: formatNumber(locale, overlappingDonors.length),
+                  })}
+                </h3>
+                <p className="text-muted-foreground mb-4 text-sm">
+                  {tCompareParties("overlapping.description")}
+                </p>
+                <div className="w-full text-sm">
+                  {/* Desktop/Tablet View */}
+                  <div className="hidden md:block">
+                    <table className="w-full table-fixed text-sm">
+                      <thead>
+                        <tr className="border-b border-gray-200 dark:border-gray-700">
+                          <th className="bg-background sticky top-[72px] left-0 z-20 w-48 px-4 py-2 text-left font-medium">
+                            {tCompareParties("donor")}
+                          </th>
+                          {allStats.map((s) => (
+                            <th
+                              key={s.party.id}
+                              className="bg-background sticky top-[72px] z-10 px-4 py-2"
+                            >
+                              <PartyHeader
+                                party={s.party}
+                                country={countryConfig}
+                              />
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {overlappingDonors
+                          .slice(0, OVERLAP_MAX)
+                          .map((donor) => (
+                            <tr
+                              key={donor.name}
+                              className="border-b border-gray-100 dark:border-gray-800"
+                            >
+                              <td className="bg-background sticky left-0 w-48 px-4 py-2">
+                                <div className="truncate font-medium">
+                                  <DonorLink
+                                    country={countryConfig}
+                                    donor={donor.name}
+                                  />
+                                </div>
+                                <div className="text-muted-foreground text-xs tabular-nums">
+                                  {formatCompactCountryCurrency(
+                                    locale,
+                                    donor.totalSum,
+                                    countryConfig,
+                                  )}
+                                  {" · "}
+                                  {tCompareParties("n_donations", {
+                                    count: formatNumber(
+                                      locale,
+                                      donor.totalSum > 0
+                                        ? Object.values(donor.perParty).reduce(
+                                            (acc, d) => acc + d.count,
+                                            0,
+                                          )
+                                        : 0,
+                                    ),
+                                  })}
+                                </div>
+                              </td>
+                              {allStats.map((s) => {
+                                const data = donor.perParty[s.party.id];
+                                return (
+                                  <td
+                                    key={s.party.id}
+                                    className="px-4 py-2 text-right"
+                                  >
+                                    {data ? (
+                                      <TwoLineCell
+                                        primary={formatCountryCurrency(
+                                          locale,
+                                          data.sum,
+                                          countryConfig,
+                                        )}
+                                        secondary={tCompareParties(
+                                          "n_donations",
+                                          {
+                                            count: formatNumber(
+                                              locale,
+                                              data.count,
+                                            ),
+                                          },
+                                        )}
+                                      />
+                                    ) : (
+                                      <span className="text-muted-foreground">
+                                        {NO_DATA_TEXT}
+                                      </span>
+                                    )}
+                                  </td>
+                                );
+                              })}
+                            </tr>
+                          ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {/* Mobile View */}
+                  <div className="grid gap-4 md:hidden">
+                    {overlappingDonors.slice(0, OVERLAP_MAX).map((donor) => (
+                      <div key={donor.name} className="card min-w-0">
+                        <div className="border-b border-gray-100 pb-3 dark:border-gray-700">
+                          <h4 className="truncate text-base font-semibold">
+                            <DonorLink
+                              country={countryConfig}
+                              donor={donor.name}
+                            />
+                          </h4>
+                          <div className="text-muted-foreground mt-0.5 text-xs font-medium tabular-nums">
+                            {formatCompactCountryCurrency(
+                              locale,
+                              donor.totalSum,
+                              countryConfig,
+                            )}
+                            {" · "}
+                            {tCompareParties("n_donations", {
+                              count: formatNumber(
+                                locale,
+                                donor.totalSum > 0
+                                  ? Object.values(donor.perParty).reduce(
+                                      (acc, d) => acc + d.count,
+                                      0,
+                                    )
+                                  : 0,
+                              ),
+                            })}
+                          </div>
+                        </div>
+
+                        <div className="mt-3 grid gap-4">
+                          {allStats.map((s) => {
+                            const data = donor.perParty[s.party.id];
+                            return (
+                              <div
+                                key={s.party.id}
+                                className="flex min-w-0 gap-3"
+                              >
+                                <div
+                                  className="mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full"
+                                  style={{
+                                    backgroundColor: partyColor(
+                                      s.party.id,
+                                      countryConfig,
+                                    ),
+                                  }}
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <div className="text-muted-foreground mb-1 text-xs font-semibold">
+                                    {s.party.short}
+                                  </div>
+                                  <div className="min-w-0 font-medium tabular-nums">
+                                    {data ? (
+                                      <TwoLineCell
+                                        primary={formatCountryCurrency(
+                                          locale,
+                                          data.sum,
+                                          countryConfig,
+                                        )}
+                                        secondary={tCompareParties(
+                                          "n_donations",
+                                          {
+                                            count: formatNumber(
+                                              locale,
+                                              data.count,
+                                            ),
+                                          },
+                                        )}
+                                      />
+                                    ) : (
+                                      <span className="text-muted-foreground">
+                                        {NO_DATA_TEXT}
+                                      </span>
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                {overlappingDonors.length > 50 && (
+                  <p className="text-muted-foreground px-4 py-2 text-sm">
+                    {tCompareParties("overlapping.more", {
+                      count: formatNumber(
+                        locale,
+                        overlappingDonors.length - OVERLAP_MAX,
+                      ),
+                    })}
+                  </p>
+                )}
+              </div>
+            )}
+          </ArticleSection>
+        </>
+      )}
+    </div>
+  );
+};
+
+/** Party column header with colored dot */
+const PartyHeader = ({
+  party,
+  country,
+}: {
+  party: Party;
+  country: CountryConfig;
+}) => (
+  <div className="flex items-center justify-end gap-1.5">
+    <span
+      className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+      style={{ backgroundColor: partyColor(party.id, country) }}
+    />
+    <span className="font-semibold">{party.short}</span>
+  </div>
+);
+
+/** Reusable comparison table: metrics as rows, parties as columns */
+const ComparisonTable = ({
+  stats,
+  rows,
+  countryConfig,
+}: {
+  stats: PartyStats[];
+  rows: ComparisonRow[];
+  countryConfig: CountryConfig;
+}) => (
+  <div className="w-full text-sm">
+    {/* Desktop/Tablet View (Table) */}
+    <div className="hidden md:block">
+      <table className="w-full table-fixed text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 dark:border-gray-700">
+            <th className="bg-background sticky top-[72px] left-0 z-20 w-48 px-4 py-3 text-left font-medium" />
+            {stats.map((s) => (
+              <th
+                key={s.party.id}
+                className="bg-background sticky top-[72px] z-10 px-4 py-3"
+              >
+                <PartyHeader party={s.party} country={countryConfig} />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.label}
+              className="border-b border-gray-100 dark:border-gray-800"
+            >
+              <td className="bg-background text-muted-foreground sticky left-0 w-48 px-4 py-2.5 text-sm">
+                {row.label}
+              </td>
+              {stats.map((s) => {
+                const isWinner = row.winner === s.party.id;
+                return (
+                  <td
+                    key={s.party.id}
+                    className={`px-4 py-2.5 font-medium ${
+                      isWinner
+                        ? "bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400"
+                        : ""
+                    }`}
+                  >
+                    <div className="flex items-baseline justify-between gap-1">
+                      <span className="w-4 shrink-0">
+                        {isWinner && <Trophy className="h-3.5 w-3.5" />}
+                      </span>
+                      <div className="min-w-0 flex-1 text-right tabular-nums">
+                        {row.values(s)}
+                      </div>
+                    </div>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+
+    {/* Mobile View (Stacked Cards) */}
+    <div className="grid gap-4 md:hidden">
+      {rows.map((row) => (
+        <div key={row.label} className="card min-w-0">
+          <h4 className="border-b border-gray-100 pb-2 text-sm font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            {row.label}
+          </h4>
+          <div className="mt-3 grid gap-4">
+            {stats.map((s) => {
+              const isWinner = row.winner === s.party.id;
+              return (
+                <div key={s.party.id} className="flex min-w-0 gap-3">
+                  <div
+                    className="mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor: partyColor(s.party.id, countryConfig),
+                    }}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-muted-foreground mb-1 flex items-center justify-between text-xs font-semibold">
+                      <span>{s.party.short}</span>
+                      {isWinner && (
+                        <Trophy className="h-3.5 w-3.5 text-amber-500" />
+                      )}
+                    </div>
+                    <div className="min-w-0 font-medium tabular-nums">
+                      {row.values(s)}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+/** Two-line cell: primary text on top, secondary muted text below */
+const TwoLineCell = ({
+  primary,
+  secondary,
+}: {
+  primary: ReactNode;
+  secondary: ReactNode;
+}) => (
+  <div className="w-full min-w-0 tabular-nums">
+    <div
+      className="truncate"
+      title={typeof primary === "string" ? primary : undefined}
+    >
+      {primary}
+    </div>
+    <div className="text-muted-foreground truncate text-xs font-normal">
+      {secondary}
+    </div>
+  </div>
+);

--- a/src/components/year-range-selector.tsx
+++ b/src/components/year-range-selector.tsx
@@ -1,0 +1,192 @@
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+import { cn } from "../utils/classname";
+
+import type { CountryConfig } from "../utils/countries";
+
+export const YearRangeSelector = ({
+  countryConfig,
+  fromYear,
+  toYear,
+  setFromYear,
+  setToYear,
+  showAllYears,
+}: {
+  countryConfig: CountryConfig;
+  fromYear: string;
+  toYear: string;
+  setFromYear: (year: string) => void;
+  setToYear: (year: string) => void;
+  showAllYears?: boolean;
+}) => {
+  const tSearch = useTranslations("search");
+  const tBarChartRace = useTranslations("bar_chart_race");
+
+  const handleFromYearChange = (year: string) => {
+    if (year > toYear) {
+      setToYear(year);
+    }
+    setFromYear(year);
+  };
+
+  const handleToYearChange = (year: string) => {
+    if (year < fromYear) {
+      setFromYear(year);
+    }
+    setToYear(year);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <fieldset className="m-0 border-0 p-0">
+        <legend className="mb-2 text-sm font-medium">
+          {tSearch("legislative_years")}
+        </legend>
+        <div className="flex flex-wrap gap-2">
+          {showAllYears && (
+            <Button
+              variant={
+                fromYear === countryConfig.years[0] &&
+                toYear === countryConfig.years[countryConfig.years.length - 1]
+                  ? "default"
+                  : "outline"
+              }
+              onClick={() => {
+                setFromYear(countryConfig.years[0]);
+                setToYear(countryConfig.years[countryConfig.years.length - 1]);
+              }}
+            >
+              All years
+            </Button>
+          )}
+          {countryConfig.legislativeYears.map((years) => {
+            const start = years[0];
+            const end = years[years.length - 1];
+            const label = `${start}-${end}`;
+            const isActive = fromYear === start && toYear === end;
+
+            return (
+              <Button
+                key={label}
+                variant={isActive ? "default" : "outline"}
+                onClick={() => {
+                  setFromYear(start);
+                  setToYear(end);
+                }}
+              >
+                {label}
+              </Button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Individual year buttons */}
+      <fieldset className="m-0 border-0 p-0">
+        <legend className="mb-2 text-sm font-medium">
+          {tBarChartRace("individual_years")}
+        </legend>
+        <div className="flex flex-wrap gap-2">
+          {countryConfig.years.map((year) => {
+            const isActive = fromYear === year && toYear === year;
+            return (
+              <Button
+                key={year}
+                variant={isActive ? "default" : "outline"}
+                size="sm"
+                onClick={() => {
+                  setFromYear(year);
+                  setToYear(year);
+                }}
+              >
+                {year}
+              </Button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Advanced year range selection */}
+      <details className="group">
+        <summary className="text-accent-foreground hover:text-foreground cursor-pointer text-sm font-medium">
+          {tBarChartRace("custom_range")}
+        </summary>
+        <div className="mt-2 flex flex-row items-center gap-2">
+          <label htmlFor="from-year-select" className="text-sm font-medium">
+            {tBarChartRace("from")}
+          </label>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              id="from-year-select"
+              render={
+                <Button variant="outline" className="w-32 justify-between" />
+              }
+            >
+              {fromYear}
+              <ChevronDownIcon className="size-4 opacity-50" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="h-64">
+              {countryConfig.years.map((year) => (
+                <DropdownMenuItem
+                  key={year}
+                  onClick={() => handleFromYearChange(year)}
+                  disabled={year > toYear}
+                  className={cn(
+                    "flex justify-between",
+                    year === fromYear &&
+                      "bg-accent text-accent-foreground font-bold",
+                  )}
+                >
+                  {year}
+                  {year === fromYear && <CheckIcon className="size-4" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <span className="text-muted-foreground">-</span>
+          <label htmlFor="to-year-select" className="text-sm font-medium">
+            {tBarChartRace("to")}
+          </label>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              id="to-year-select"
+              render={
+                <Button variant="outline" className="w-32 justify-between" />
+              }
+            >
+              {toYear}
+              <ChevronDownIcon className="size-4 opacity-50" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="h-64">
+              {countryConfig.years.map((year) => (
+                <DropdownMenuItem
+                  key={year}
+                  onClick={() => handleToYearChange(year)}
+                  disabled={year < fromYear}
+                  className={cn(
+                    "flex justify-between",
+                    year === toYear &&
+                      "bg-accent text-accent-foreground font-bold",
+                  )}
+                >
+                  {year}
+                  {year === toYear && <CheckIcon className="size-4" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </details>
+    </div>
+  );
+};

--- a/src/messages/cs.json
+++ b/src/messages/cs.json
@@ -691,5 +691,59 @@
     },
     "chart_title": "Rozložení stranických darů",
     "chart_subtitle": "Celkové zveřejněné dary jednotlivým stranám, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Porovnat strany",
+    "description": "Vyberte níže mezi dvěma až čtyřmi stranami pro porovnání jejich statistik darů vedle sebe. Limit čtyř stran zajišťuje, že porovnání zůstane přehledné na všech obrazovkách."
+  },
+  "compare_parties": {
+    "parties": "Strany",
+    "min_select": "Vyberte alespoň dvě strany výše, abyste viděli porovnání.",
+    "comparing": "Porovnávání",
+    "years": "Roky",
+    "top_3_donors": "Top 3 dárci",
+    "n_donations": "{count} darů",
+    "donor_type": "Typ dárce",
+    "donor": "Dárce",
+    "overview": {
+      "title": "Přehled",
+      "description": "Obecné statistiky včetně celkové částky a počtu darů, které jednotlivé strany získaly ve zvoleném časovém období."
+    },
+    "timeline": {
+      "title": "Časová osa",
+      "description": "Chronologický přehled ukazující, kdy strany přijaly svůj první a poslední dar, a jejich nejaktivnější finanční období."
+    },
+    "top_donations": {
+      "title": "Největší dary",
+      "description": "Zvýrazňuje největší jednotlivý dar a nejštědřejší individuální dárce pro každou vybranou stranu."
+    },
+    "donor_types": {
+      "title": "Typy dárců",
+      "description": "Analýza finanční podpory podle typu subjektu, jako jsou firmy, jednotlivci nebo odbory.",
+      "biggest_donor_type": "Největší typ dárce"
+    },
+    "donors": {
+      "title": "Dárci",
+      "description": "Podrobnější pohled na osoby a organizace podporující jednotlivé strany, včetně četnosti a překryvů darů."
+    },
+    "overlapping": {
+      "title": "Překrývající se dárci ({count})",
+      "description": "Dárci, kteří přispěli více vybraným stranám.",
+      "more": "... a {count} dalších"
+    },
+    "stats": {
+      "sum": "Celková částka darů",
+      "count": "Počet darů",
+      "avg": "Průměrný dar",
+      "median": "Medián daru",
+      "first_year": "První rok daru",
+      "last_year": "Poslední rok daru",
+      "active_year_sum": "Nejaktivnější rok (podle částky)",
+      "active_year_count": "Rok s největším počtem darů",
+      "unique_donors": "Jedineční dárci",
+      "top_donor": "Největší dárce",
+      "frequent_donor": "Nejčastější dárce",
+      "biggest_donation": "Největší jednotlivý dar"
+    }
   }
 }

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -691,5 +691,59 @@
     },
     "chart_title": "Verteilung der Parteispenden",
     "chart_subtitle": "Gesamtveröffentlichte Spenden an jede Partei, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Parteien vergleichen",
+    "description": "Wählen Sie unten zwischen zwei und vier Parteien aus, um ihre Spendenstatistiken nebeneinander zu vergleichen. Das Limit von 4 Parteien stellt sicher, dass der Vergleich auf allen Bildschirmen lesbar bleibt."
+  },
+  "compare_parties": {
+    "parties": "Parteien",
+    "min_select": "Wählen Sie oben mindestens zwei Parteien aus, um einen Vergleich zu sehen.",
+    "comparing": "Vergleiche",
+    "years": "Jahre",
+    "top_3_donors": "Top 3 Spender",
+    "n_donations": "{count} Spenden",
+    "donor_type": "Spenderart",
+    "donor": "Spender",
+    "overview": {
+      "title": "Übersicht",
+      "description": "Allgemeine Statistiken, einschließlich der Gesamtsumme und der Anzahl der Spenden, die jede Partei im ausgewählten Zeitraum erhalten hat."
+    },
+    "timeline": {
+      "title": "Zeitverlauf",
+      "description": "Eine chronologische Übersicht zeigt, wann die Parteien ihre ersten und letzten Spenden erhielten sowie ihre finanziell aktivsten Phasen."
+    },
+    "top_donations": {
+      "title": "Höchste Spenden",
+      "description": "Hebt die größte einzelne eingegangene Transaktion und die höchsten Einzeldonoren für jede ausgewählte Partei hervor."
+    },
+    "donor_types": {
+      "title": "Spenderarten",
+      "description": "Eine Analyse der finanziellen Unterstützung nach Entitätstypen, wie Unternehmen, Einzelpersonen oder Gewerkschaften.",
+      "biggest_donor_type": "Größte Spenderart"
+    },
+    "donors": {
+      "title": "Spender",
+      "description": "Ein tieferer Einblick in die einzelnen Personen und Organisationen, die jede Partei unterstützen, einschließlich Häufigkeit und Überschneidungen."
+    },
+    "overlapping": {
+      "title": "Überschneidende Spender ({count})",
+      "description": "Spender, die an mehrere der ausgewählten Parteien gespendet haben.",
+      "more": "... und {count} weitere"
+    },
+    "stats": {
+      "sum": "Gesamtspenden",
+      "count": "Anzahl der Spenden",
+      "avg": "Durchschnittliche Spende",
+      "median": "Median-Spende",
+      "first_year": "Jahr der ersten Spende",
+      "last_year": "Jahr der letzten Spende",
+      "active_year_sum": "Aktivstes Jahr (nach Summe)",
+      "active_year_count": "Jahr mit den meisten Spenden",
+      "unique_donors": "Einzigartige Spender",
+      "top_donor": "Top-Spender",
+      "frequent_donor": "Häufigster Spender",
+      "biggest_donation": "Größte Einzelspende"
+    }
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -675,5 +675,59 @@
     },
     "chart_title": "Distribution of party donations",
     "chart_subtitle": "Total published donations to each party, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Compare parties",
+    "description": "Select between two and four parties below to compare their donation statistics side-by-side. The limit of 4 parties ensures the comparison remains readable on all screens."
+  },
+  "compare_parties": {
+    "parties": "Parties",
+    "min_select": "Select at least two parties above to see a comparison.",
+    "comparing": "Comparing",
+    "years": "Years",
+    "top_3_donors": "Top 3 donors",
+    "n_donations": "{count} donations",
+    "donor_type": "Donor type",
+    "donor": "Donor",
+    "overview": {
+      "title": "Overview",
+      "description": "General statistics including the total sum and number of donations received by each party within the selected timeframe."
+    },
+    "timeline": {
+      "title": "Timeline",
+      "description": "A chronological breakdown showing when parties received their first and last donations, as well as their most financially active periods."
+    },
+    "top_donations": {
+      "title": "Top donations",
+      "description": "Highlights the largest single incoming transaction and the highest individual donors for each selected party."
+    },
+    "donor_types": {
+      "title": "Donor types",
+      "description": "An analysis of financial support categorized by entity types, such as companies, individuals, or trade unions.",
+      "biggest_donor_type": "Biggest donor type"
+    },
+    "donors": {
+      "title": "Donors",
+      "description": "A deeper look into the unique individuals and organizations backing each party, including frequency and overlapping contributions."
+    },
+    "overlapping": {
+      "title": "Overlapping donors ({count})",
+      "description": "Donors who donated to multiple selected parties.",
+      "more": "... and {count} more"
+    },
+    "stats": {
+      "sum": "Total donations",
+      "count": "Number of donations",
+      "avg": "Average donation",
+      "median": "Median donation",
+      "first_year": "First donation year",
+      "last_year": "Last donation year",
+      "active_year_sum": "Most active year (by sum)",
+      "active_year_count": "Year with most donations",
+      "unique_donors": "Unique donors",
+      "top_donor": "Top donor",
+      "frequent_donor": "Most frequent donor",
+      "biggest_donation": "Largest single donation"
+    }
   }
 }

--- a/src/messages/et.json
+++ b/src/messages/et.json
@@ -691,5 +691,59 @@
     },
     "chart_title": "Erakondade annetuste jaotus",
     "chart_subtitle": "Kokku avaldatud annetused iga erakonna kohta, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Võrdle erakondi",
+    "description": "Vali allpool kahe kuni nelja erakonna vahel, et võrrelda nende annetuste statistikat kõrvuti. Nelja erakonna piirang tagab, et võrdlus jääb kõigil ekraanidel loetavaks."
+  },
+  "compare_parties": {
+    "parties": "Erakonnad",
+    "min_select": "Vali ülal vähemalt kaks erakonda, et näha võrdlust.",
+    "comparing": "Võrdlus",
+    "years": "Aastad",
+    "top_3_donors": "Top 3 annetajat",
+    "n_donations": "{count} annetust",
+    "donor_type": "Annetaja tüüp",
+    "donor": "Annetaja",
+    "overview": {
+      "title": "Ülevaade",
+      "description": "Üldstatistika, sealhulgas iga erakonna saadud annetuste kogusumma ja arv valitud ajavahemikus."
+    },
+    "timeline": {
+      "title": "Ajajoon",
+      "description": "Kronoloogiline jaotus, mis näitab, millal erakonnad said oma esimese ja viimase annetuse ning millal olid nende finantsiliselt aktiivseimad perioodid."
+    },
+    "top_donations": {
+      "title": "Suurimad annetused",
+      "description": "Toob esile suurima üksiku sissetuleva tehingu ja suurimad individuaalsed annetajad iga valitud erakonna jaoks."
+    },
+    "donor_types": {
+      "title": "Annetajate tüübid",
+      "description": "Finantstoetuse analüüs, jaotatuna üksuse tüübi järgi, näiteks ettevõtted, eraisikud või ametiühingud.",
+      "biggest_donor_type": "Suurim annetaja tüüp"
+    },
+    "donors": {
+      "title": "Annetajad",
+      "description": "Põhjalikum vaade unikaalsetesse isikutesse ja organisatsioonidesse, kes iga erakonda toetavad, sh annetuste sagedus ja kattuvad panused."
+    },
+    "overlapping": {
+      "title": "Kattuvad annetajad ({count})",
+      "description": "Annetajad, kes on teinud annetusi mitmele valitud erakonnale.",
+      "more": "... ja veel {count}"
+    },
+    "stats": {
+      "sum": "Annetuste kogusumma",
+      "count": "Annetuste arv",
+      "avg": "Keskmine annetus",
+      "median": "Mediaanannetus",
+      "first_year": "Esimene annetuse aasta",
+      "last_year": "Viimane annetuse aasta",
+      "active_year_sum": "Aktiivseim aasta (summa järgi)",
+      "active_year_count": "Aasta kõige rohkemate annetustega",
+      "unique_donors": "Unikaalsed annetajad",
+      "top_donor": "Suurim annetaja",
+      "frequent_donor": "Kõige sagedasem annetaja",
+      "biggest_donation": "Suurim üksik annetus"
+    }
   }
 }

--- a/src/messages/hr.json
+++ b/src/messages/hr.json
@@ -691,5 +691,59 @@
     },
     "chart_title": "Raspodjela donacija strankama",
     "chart_subtitle": "Ukupne objavljene donacije svakoj stranci, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Usporedi stranke",
+    "description": "Ispod odaberite između dvije i četiri stranke kako biste usporedili njihovu statistiku donacija usporedno. Ograničenje od četiri stranke osigurava da usporedba ostane čitka na svim zaslonima."
+  },
+  "compare_parties": {
+    "parties": "Stranke",
+    "min_select": "Odaberite najmanje dvije stranke iznad kako biste vidjeli usporedbu.",
+    "comparing": "Uspoređivanje",
+    "years": "Godine",
+    "top_3_donors": "Top 3 donatora",
+    "n_donations": "{count} donacija",
+    "donor_type": "Tip donatora",
+    "donor": "Donator",
+    "overview": {
+      "title": "Pregled",
+      "description": "Opća statistika, uključujući ukupni iznos i broj donacija koje je svaka stranka primila u odabranom razdoblju."
+    },
+    "timeline": {
+      "title": "Vremenska crta",
+      "description": "Kronološki prikaz koji pokazuje kada su stranke primile svoju prvu i posljednju donaciju, kao i svoja financijski najaktivnija razdoblja."
+    },
+    "top_donations": {
+      "title": "Najveće donacije",
+      "description": "Ističe najveću pojedinačnu dolaznu transakciju i najveće pojedinačne donatore za svaku odabranu stranku."
+    },
+    "donor_types": {
+      "title": "Tipovi donatora",
+      "description": "Analiza financijske potpore razvrstane prema tipu subjekta, poput tvrtki, pojedinaca ili sindikata.",
+      "biggest_donor_type": "Najveći tip donatora"
+    },
+    "donors": {
+      "title": "Donatori",
+      "description": "Detaljniji uvid u jedinstvene osobe i organizacije koje podupiru svaku stranku, uključujući učestalost i preklapanje donacija."
+    },
+    "overlapping": {
+      "title": "Preklapajući donatori ({count})",
+      "description": "Donatori koji su donirali višestrukim odabranim strankama.",
+      "more": "... i još {count}"
+    },
+    "stats": {
+      "sum": "Ukupne donacije",
+      "count": "Broj donacija",
+      "avg": "Prosječna donacija",
+      "median": "Medijan donacije",
+      "first_year": "Prva godina donacije",
+      "last_year": "Zadnja godina donacije",
+      "active_year_sum": "Najaktivnija godina (prema iznosu)",
+      "active_year_count": "Godina s najviše donacija",
+      "unique_donors": "Jedinstveni donatori",
+      "top_donor": "Najveći donator",
+      "frequent_donor": "Najčešći donator",
+      "biggest_donation": "Najveća pojedinačna donacija"
+    }
   }
 }

--- a/src/messages/lv.json
+++ b/src/messages/lv.json
@@ -691,5 +691,59 @@
     },
     "chart_title": "Partiju ziedojumu sadalījums",
     "chart_subtitle": "Kopējie publicētie ziedojumi katrai partijai, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Salīdzināt partijas",
+    "description": "Zemāk izvēlieties no divām līdz četrām partijām, lai salīdzinātu to ziedojumu statistiku līdzās. Četru partiju ierobežojums nodrošina, ka salīdzinājums paliek pārskatāms uz visiem ekrāniem."
+  },
+  "compare_parties": {
+    "parties": "Partijas",
+    "min_select": "Izvēlieties vismaz divas partijas augstāk, lai redzētu salīdzinājumu.",
+    "comparing": "Salīdzināšana",
+    "years": "Gadi",
+    "top_3_donors": "Top 3 ziedotāji",
+    "n_donations": "{count} ziedojumi",
+    "donor_type": "Ziedotāja tips",
+    "donor": "Ziedotājs",
+    "overview": {
+      "title": "Pārskats",
+      "description": "Vispārīga statistika, tostarp katras partijas saņemto ziedojumu kopējā summa un skaits izvēlētajā laika periodā."
+    },
+    "timeline": {
+      "title": "Laika skala",
+      "description": "Hronoloģisks pārskats, kas parāda, kad partijas saņēma savu pirmo un pēdējo ziedojumu, kā arī to finansiāli aktīvākos periodus."
+    },
+    "top_donations": {
+      "title": "Lielākie ziedojumi",
+      "description": "Izceļ lielāko vienreizējo ienākošo darījumu un lielākos individuālos ziedotājus katrai izvēlētajai partijai."
+    },
+    "donor_types": {
+      "title": "Ziedotāju tipi",
+      "description": "Finansiālā atbalsta analīze, grupēta pēc subjekta tipa, piemēram, uzņēmumi, fiziskas personas vai arodbiedrības.",
+      "biggest_donor_type": "Lielākais ziedotāja tips"
+    },
+    "donors": {
+      "title": "Ziedotāji",
+      "description": "Detalizētāks ieskats unikālajās personās un organizācijās, kas atbalsta katru partiju, tostarp ziedojumu biežums un pārklāšanās."
+    },
+    "overlapping": {
+      "title": "Pārklājošies ziedotāji ({count})",
+      "description": "Ziedotāji, kas ziedojuši vairākām izvēlētajām partijām.",
+      "more": "... un vēl {count}"
+    },
+    "stats": {
+      "sum": "Kopējie ziedojumi",
+      "count": "Ziedojumu skaits",
+      "avg": "Vidējais ziedojums",
+      "median": "Mediānais ziedojums",
+      "first_year": "Pirmais ziedošanas gads",
+      "last_year": "Pēdējais ziedošanas gads",
+      "active_year_sum": "Aktīvākais gads (pēc summas)",
+      "active_year_count": "Gads ar visvairāk ziedojumiem",
+      "unique_donors": "Unikālie ziedotāji",
+      "top_donor": "Lielākais ziedotājs",
+      "frequent_donor": "Biežākais ziedotājs",
+      "biggest_donation": "Lielākais vienreizējais ziedojums"
+    }
   }
 }

--- a/src/messages/nl.json
+++ b/src/messages/nl.json
@@ -691,5 +691,59 @@
     },
     "chart_title": "Verdeling van partijdonaties",
     "chart_subtitle": "Totaal gepubliceerde donaties aan elke partij, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Partijen vergelijken",
+    "description": "Selecteer hieronder tussen twee en vier partijen om hun donatiestatistieken naast elkaar te vergelijken. De limiet van vier partijen zorgt ervoor dat de vergelijking op alle schermen leesbaar blijft."
+  },
+  "compare_parties": {
+    "parties": "Partijen",
+    "min_select": "Selecteer hierboven minimaal twee partijen om een vergelijking te zien.",
+    "comparing": "Vergelijken",
+    "years": "Jaren",
+    "top_3_donors": "Top 3 donoren",
+    "n_donations": "{count} donaties",
+    "donor_type": "Donortype",
+    "donor": "Donor",
+    "overview": {
+      "title": "Overzicht",
+      "description": "Algemene statistieken, inclusief het totale bedrag en het aantal donaties dat elke partij in de geselecteerde periode heeft ontvangen."
+    },
+    "timeline": {
+      "title": "Tijdlijn",
+      "description": "Een chronologisch overzicht dat laat zien wanneer partijen hun eerste en laatste donatie ontvingen, evenals hun financieel meest actieve perioden."
+    },
+    "top_donations": {
+      "title": "Hoogste donaties",
+      "description": "Licht de grootste enkele binnenkomende transactie en de belangrijkste individuele donoren voor elke geselecteerde partij uit."
+    },
+    "donor_types": {
+      "title": "Donortypen",
+      "description": "Een analyse van financiële steun, gecategoriseerd naar type entiteit, zoals bedrijven, individuen of vakbonden.",
+      "biggest_donor_type": "Grootste donortype"
+    },
+    "donors": {
+      "title": "Donoren",
+      "description": "Een diepere blik op de unieke personen en organisaties die elke partij steunen, inclusief frequentie en overlappende bijdragen."
+    },
+    "overlapping": {
+      "title": "Overlappende donoren ({count})",
+      "description": "Donoren die aan meerdere geselecteerde partijen hebben gedoneerd.",
+      "more": "... en nog {count} meer"
+    },
+    "stats": {
+      "sum": "Totale donaties",
+      "count": "Aantal donaties",
+      "avg": "Gemiddelde donatie",
+      "median": "Mediandonatie",
+      "first_year": "Eerste donatiejaar",
+      "last_year": "Laatste donatiejaar",
+      "active_year_sum": "Meest actieve jaar (op bedrag)",
+      "active_year_count": "Jaar met de meeste donaties",
+      "unique_donors": "Unieke donoren",
+      "top_donor": "Topdonor",
+      "frequent_donor": "Meest frequente donor",
+      "biggest_donation": "Grootste enkele donatie"
+    }
   }
 }

--- a/src/messages/no.json
+++ b/src/messages/no.json
@@ -691,5 +691,59 @@
     },
     "chart_title": "Fordeling av partidonasjoner",
     "chart_subtitle": "Totalt publiserte donasjoner til hvert parti, {country}, {years}."
+  },
+  "compare_parties_page": {
+    "title": "Sammenlign partier",
+    "description": "Velg mellom to og fire partier nedenfor for å sammenligne donasjonsstatistikken deres side om side. Begrensningen på fire partier sørger for at sammenligningen forblir lesbar på alle skjermer."
+  },
+  "compare_parties": {
+    "parties": "Partier",
+    "min_select": "Velg minst to partier ovenfor for å se en sammenligning.",
+    "comparing": "Sammenligner",
+    "years": "År",
+    "top_3_donors": "Topp 3 givere",
+    "n_donations": "{count} donasjoner",
+    "donor_type": "Givertype",
+    "donor": "Giver",
+    "overview": {
+      "title": "Oversikt",
+      "description": "Generell statistikk, inkludert den totale summen og antall donasjoner hver part har mottatt i valgt tidsrom."
+    },
+    "timeline": {
+      "title": "Tidslinje",
+      "description": "En kronologisk oversikt som viser når partiene mottok sine første og siste donasjoner, samt deres mest finansielt aktive perioder."
+    },
+    "top_donations": {
+      "title": "Største donasjoner",
+      "description": "Fremhever den største enkeltstående innbetalingstransaksjonen og de største individuelle giverne for hver valgt part."
+    },
+    "donor_types": {
+      "title": "Givertyper",
+      "description": "En analyse av økonomisk støtte kategorisert etter enhetstype, som selskaper, privatpersoner eller fagforeninger.",
+      "biggest_donor_type": "Største givertype"
+    },
+    "donors": {
+      "title": "Givere",
+      "description": "Et dypere innblikk i de unike personene og organisasjonene som støtter hver part, inkludert hyppighet og overlappende bidrag."
+    },
+    "overlapping": {
+      "title": "Overlappende givere ({count})",
+      "description": "Givere som har donert til flere av de valgte partiene.",
+      "more": "... og {count} til"
+    },
+    "stats": {
+      "sum": "Totale donasjoner",
+      "count": "Antall donasjoner",
+      "avg": "Gjennomsnittlig donasjon",
+      "median": "Median-donasjon",
+      "first_year": "Første donasjonsår",
+      "last_year": "Siste donasjonsår",
+      "active_year_sum": "Mest aktive år (etter sum)",
+      "active_year_count": "Året med flest donasjoner",
+      "unique_donors": "Unike givere",
+      "top_donor": "Største giver",
+      "frequent_donor": "Mest hyppige giver",
+      "biggest_donation": "Største enkeltstående donasjon"
+    }
   }
 }

--- a/src/utils/i18n-filter.ts
+++ b/src/utils/i18n-filter.ts
@@ -15,6 +15,7 @@ export const SERVER_ONLY_NAMESPACES = [
   "home",
   "thanks",
   "export",
+  "compare_parties_page",
 ] as const;
 
 type ServerOnlyNamespace = (typeof SERVER_ONLY_NAMESPACES)[number];


### PR DESCRIPTION
## Description
Adds an initial party comparison tool. Right now the scope is limited to tabular data. In the future we can add charts here.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Data update/addition
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Unit tests pass (`pnpm test:unit`)
- [x] Lint passes (`pnpm lint`)
- [x] E2E tests pass (`pnpm test:e2e`) - if UI changes

## Screenshots
<img width="1280" height="4630" alt="localhost_3000_en_unitedkingdom_tools_compare_parties=TORIES,LABOUR,REFORM,GPEW from=2020 to=2026" src="https://github.com/user-attachments/assets/61aa21ee-889d-4905-9568-0d4baa59f03d" />

