### PR TITLE
refactor: extract country features into separate field using bitmasks

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "@playwright/test";
 
 import { COUNTRIES } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 
 import { test } from "./util/fixture";
 
@@ -30,7 +31,7 @@ test.describe("Homepage", () => {
 
         await test.step("has biggest donations text", async () => {
           await expect(homePage.biggestDonations).toBeVisible({
-            visible: !countryConfig.hasNoDonors,
+            visible: hasFeature(countryConfig, Features.Donors),
           });
         });
 
@@ -43,7 +44,7 @@ test.describe("Homepage", () => {
           await expect(homePage.currentLegislativePeriod.locator).toBeVisible();
 
           const cc = await getCountryConfig(country);
-          if (cc.hasDate) {
+          if (hasFeature(cc, Features.Date)) {
             await expect(homePage.mostRecentDonations).toBeVisible();
           }
 

--- a/e2e/year-page.spec.ts
+++ b/e2e/year-page.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "@playwright/test";
 
 import { COUNTRIES, Country } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { getPartyYearsSums } from "@/utils/loader/party-years-sums";
 import { canShowYearsTimeline } from "@/utils/party";
 
@@ -103,7 +104,7 @@ test.describe("Year page", () => {
         test.describe("donors page", () => {
           test.beforeEach(async ({ page, baseURL }) => {
             test.skip(
-              Boolean((await getCountryConfig(country)).hasNoDonors),
+              !hasFeature(await getCountryConfig(country), Features.Donors),
               "Country has no donors",
             );
 
@@ -157,7 +158,7 @@ test.describe("Year page", () => {
             const partyYearSums = await getPartyYearsSums(country);
 
             test.skip(
-              !countryConfig.hasDate,
+              !hasFeature(countryConfig, Features.Date),
               "Country does not have dates and in turn no timeline",
             );
             test.skip(
@@ -199,7 +200,7 @@ test.describe("Year page", () => {
         test.describe("origin page", () => {
           test.beforeEach(async ({ page, baseURL }) => {
             test.skip(
-              !(await getCountryConfig(country)).hasOrigin,
+              !hasFeature(await getCountryConfig(country), Features.Origin),
               "Country does not have origin",
             );
 

--- a/src/app/[locale]/[country]/[years]/donors/page.tsx
+++ b/src/app/[locale]/[country]/[years]/donors/page.tsx
@@ -19,6 +19,7 @@ import {
 import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { getParties } from "@/utils/data/get-parties";
+import { Features, hasFeature } from "@/utils/features";
 import { formatYearsRange } from "@/utils/formatter";
 import {
   getPartyYearsSums,
@@ -84,7 +85,7 @@ export default async function YearPage(
     getPartyYearsSums(country),
   ]);
 
-  if (countryConfig.hasNoDonors) {
+  if (!hasFeature(countryConfig, Features.Donors)) {
     return notFound();
   }
 

--- a/src/app/[locale]/[country]/[years]/layout.tsx
+++ b/src/app/[locale]/[country]/[years]/layout.tsx
@@ -16,6 +16,7 @@ import { isNotNullandNotUndefined } from "@/utils/array";
 import { THUMBNAIL_PREFIX } from "@/utils/config";
 import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { formatYearsRange } from "@/utils/formatter";
 import {
   getPartyYearsSums,
@@ -151,14 +152,14 @@ export default async function YearsLayout(
       href: `/${locale}/${country}/${yearsLink}/changes`,
       label: t("changes.title"),
     },
-    countryConfig.hasNoDonors
-      ? undefined
-      : {
+    hasFeature(countryConfig, Features.Donors)
+      ? {
           icon: UserRound,
           href: `/${locale}/${country}/${yearsLink}/donors`,
           activeHref: `/${locale}/${country}/${yearsLink}/donors`,
           label: t("donors.title"),
-        },
+        }
+      : undefined,
     canShowYearsTimeline(countryConfig, partySums, years)
       ? {
           icon: ChartLine,
@@ -166,7 +167,7 @@ export default async function YearsLayout(
           label: t("timeline.title"),
         }
       : undefined,
-    countryConfig.hasOrigin
+    hasFeature(countryConfig, Features.Origin)
       ? {
           icon: Earth,
           href: `/${locale}/${country}/${yearsLink}/origin/overview`,

--- a/src/app/[locale]/[country]/[years]/origin/layout.tsx
+++ b/src/app/[locale]/[country]/[years]/origin/layout.tsx
@@ -5,6 +5,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { formatYearsRange } from "@/utils/formatter";
 import {
   getPartyYearsSums,
@@ -66,7 +67,7 @@ export default async function OriginLayout(
     getPartyYearsSums(country),
   ]);
 
-  if (!countryConfig.hasOrigin) {
+  if (!hasFeature(countryConfig, Features.Origin)) {
     return notFound();
   }
 

--- a/src/app/[locale]/[country]/[years]/timeline/page.tsx
+++ b/src/app/[locale]/[country]/[years]/timeline/page.tsx
@@ -20,6 +20,7 @@ import { LoadingYearTimeseriesText } from "@/components/loading/loading-year-tim
 import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { getParties } from "@/utils/data/get-parties";
+import { Features, hasFeature } from "@/utils/features";
 import { formatYearsRange } from "@/utils/formatter";
 import {
   getPartyYearsSums,
@@ -110,7 +111,9 @@ export default async function TimelinePage(
   const parties = getParties(countryConfig, years);
 
   const resolution =
-    !hasYearOnlyDonations && countryConfig.hasDate ? "month" : "year";
+    !hasYearOnlyDonations && hasFeature(countryConfig, Features.Date)
+      ? "month"
+      : "year";
   const chartStrings =
     resolution === "month"
       ? {
@@ -166,11 +169,12 @@ export default async function TimelinePage(
               title={t(chartStrings.title)}
             />
 
-            {resolution === "year" && countryConfig.hasDate && (
-              <div className="mb-6">
-                <InfoAlert text={t("timeline.year_resolution_note")} />
-              </div>
-            )}
+            {resolution === "year" &&
+              hasFeature(countryConfig, Features.Date) && (
+                <div className="mb-6">
+                  <InfoAlert text={t("timeline.year_resolution_note")} />
+                </div>
+              )}
 
             <p className="mb-6">{t(chartStrings.description)}</p>
             {resolution === "month" ? (

--- a/src/app/[locale]/[country]/donor/[donorId]/page.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/page.tsx
@@ -11,6 +11,7 @@ import {
   getDonorMeta,
 } from "@/utils/data/server-loaders";
 import { getDonationDonorName } from "@/utils/donor";
+import { Features, hasFeature } from "@/utils/features";
 import {
   formatCompactCountryCurrency,
   formatCountryCurrency,
@@ -97,8 +98,8 @@ export async function generateMetadata(
 
   if (
     isBiggestDonor &&
-    // skip images if the country has no donors
-    !countryConfig.hasNoDonors
+    // only add images if the country has no donors
+    hasFeature(countryConfig, Features.Donors)
   ) {
     // add rich metadata for biggest donors as these have pregenerated images
     metadata.openGraph = baseOpenGraph({

--- a/src/app/[locale]/[country]/page.tsx
+++ b/src/app/[locale]/[country]/page.tsx
@@ -20,6 +20,7 @@ import {
   getReferencingCountryName,
 } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import {
   formatCompactCountryCurrency,
   formatCountryCurrency,
@@ -196,7 +197,7 @@ export default async function YearsPage(
                   <br />
                 </>
               ) : null}
-              {countryConfig.hasNoDonors ? (
+              {!hasFeature(countryConfig, Features.Donors) ? (
                 <>
                   <br />
                   {tHome("what.no_donors", {
@@ -216,7 +217,7 @@ export default async function YearsPage(
               </a>
             </p>
           </div>
-          {countryConfig.hasDate ? (
+          {hasFeature(countryConfig, Features.Date) ? (
             <section
               aria-labelledby="home-most-recent-donations"
               className="flex items-center justify-center lg:basis-1/2"
@@ -275,7 +276,7 @@ export default async function YearsPage(
         <PartiesHero country={countryConfig} locale={locale} />
       </section>
 
-      {countryConfig.hasNoDonors ? null : (
+      {hasFeature(countryConfig, Features.Donors) ? (
         <section
           className="content-visibility-auto contain-intrinsic-size-[auto_1100px_auto_508px] container mx-auto p-4 pb-12 sm:pb-24"
           aria-labelledby="home-donor-list"
@@ -303,7 +304,7 @@ export default async function YearsPage(
             biggestDonations={biggestDonations}
           />
         </section>
-      )}
+      ) : null}
 
       {countryConfig.legislativeYears?.length ? (
         <section

--- a/src/app/[locale]/[country]/party/[partyId]/donors/page.tsx
+++ b/src/app/[locale]/[country]/party/[partyId]/donors/page.tsx
@@ -18,6 +18,7 @@ import { LoadingPartyDonorTypeText } from "@/components/parties/part-donor-type-
 import { PartyDonorPageText } from "@/components/parties/party-donor-page-text";
 import { getCountryName, getParty } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import {
   formatCompactCountryCurrency,
   formatCountryCurrency,
@@ -130,7 +131,7 @@ export default async function DonorPage(
         </ArticleSectionTwoColumns>
       </ArticleSectionWrapper>
 
-      {countryConfig.hasDonorType ? (
+      {hasFeature(countryConfig, Features.DonorType) ? (
         <ArticleSectionWrapper id={"sec-party-donor-types"}>
           <ArticleSectionTwoColumns>
             <ArticleSectionColumn>

--- a/src/app/[locale]/[country]/party/[partyId]/layout.tsx
+++ b/src/app/[locale]/[country]/party/[partyId]/layout.tsx
@@ -17,6 +17,7 @@ import { partyColor } from "@/utils/color";
 import { THUMBNAIL_PREFIX } from "@/utils/config";
 import { findCorrectParty, getParty } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { formatCountryCurrency, formatNumber } from "@/utils/formatter";
 import {
   getPartyYearsSums,
@@ -157,7 +158,7 @@ export default async function PartyLayout(
       href: `/${locale}/${country}/party/${party.id}/timeline`,
       label: t("timeline.title"),
     },
-    countryConfig.hasOrigin
+    hasFeature(countryConfig, Features.Origin)
       ? {
           icon: Earth,
           href: `/${locale}/${country}/party/${party.id}/origin/overview`,
@@ -191,12 +192,12 @@ export default async function PartyLayout(
           </div>
           <div className="mb-3">
             <div className="flex-row space-y-2 sm:flex sm:space-y-0 sm:space-x-10">
-              {countryConfig.hasNoDonors ? null : (
+              {hasFeature(countryConfig, Features.Donors) ? (
                 <MetaCard
                   title={t("donation_count")}
                   value={formatNumber(locale, donationCount)}
                 />
-              )}
+              ) : null}
               <MetaCard
                 title={t("sum")}
                 value={formatCountryCurrency(
@@ -205,7 +206,7 @@ export default async function PartyLayout(
                   countryConfig,
                 )}
               />
-              {!countryConfig.hasNoDonors &&
+              {hasFeature(countryConfig, Features.Donors) &&
                 showExtendedMeta &&
                 donationCount > 1 && (
                   <MetaCard

--- a/src/app/[locale]/[country]/party/[partyId]/origin/layout.tsx
+++ b/src/app/[locale]/[country]/party/[partyId]/origin/layout.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 
 import { getCountryName, getParty } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
 import { isValidCountry, isValidLocale, isValidParty } from "@/utils/validate";
 
@@ -55,7 +56,7 @@ export default async function OriginLayout(
 
   const [countryConfig] = await Promise.all([getCountryConfig(country)]);
 
-  if (!countryConfig.hasOrigin) {
+  if (!hasFeature(countryConfig, Features.Origin)) {
     return notFound();
   }
 

--- a/src/app/[locale]/[country]/party/[partyId]/timeline/page.tsx
+++ b/src/app/[locale]/[country]/party/[partyId]/timeline/page.tsx
@@ -16,6 +16,7 @@ import {
 import { PartyTimelineText } from "@/components/parties/party-timeline-text";
 import { getCountryName, getParty } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { formatYearsRange } from "@/utils/formatter";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -79,7 +80,7 @@ export default async function TimelinePage(
 
   return (
     <Article fullWidth={true}>
-      {countryConfig.hasDate ? (
+      {hasFeature(countryConfig, Features.Date) ? (
         <ArticleSectionWrapper id={"sec-timeline"}>
           <ArticleSectionOneColumns>
             <ArticleSectionColumn>
@@ -117,7 +118,7 @@ export default async function TimelinePage(
       <ArticleSectionWrapper id={"sec-per-year"}>
         <ArticleSectionTwoColumns>
           <ArticleSectionColumn>
-            {countryConfig.hasDate ? null : (
+            {hasFeature(countryConfig, Features.Date) ? null : (
               <ArticleSectionTitle
                 as={"h1"}
                 id={"sec-timeline"}

--- a/src/app/[locale]/[country]/tools/bar-chart-race/page.tsx
+++ b/src/app/[locale]/[country]/tools/bar-chart-race/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 
 import { Article } from "@/components/layout/article";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { LOCALES } from "@/utils/locales";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -57,19 +58,17 @@ export default async function Page(
     getCountryConfig(country),
   ]);
 
-  if (!countryConfig.hasDate) {
+  if (!hasFeature(countryConfig, Features.Date)) {
     return notFound();
   }
 
   return (
     <Article title={tBarChartRace("title")}>
-      {countryConfig.hasDate ? (
-        <>
-          <p className="mb-8 max-w-prose">{tBarChartRace("description")}</p>
-          <p className="mb-8 max-w-prose text-sm">{tBarChartRace("note")}</p>
-          <RacingBars countryConfig={countryConfig} />
-        </>
-      ) : null}
+      <>
+        <p className="mb-8 max-w-prose">{tBarChartRace("description")}</p>
+        <p className="mb-8 max-w-prose text-sm">{tBarChartRace("note")}</p>
+        <RacingBars countryConfig={countryConfig} />
+      </>
     </Article>
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,6 +8,7 @@ import type { ConstLocale } from "@/utils/locales";
 import { BASE_URL } from "@/utils/config";
 import { COUNTRIES } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { getBiggestDonors } from "@/utils/loader/biggest-donors";
 import { getBuild } from "@/utils/loader/build";
 import {
@@ -91,9 +92,10 @@ export default async function sitemap(props: {
 
             const filterConditionalSubPages =
               (section: "year" | "party") => (subPage: string) => {
-                if (subPage.startsWith("origin")) return config.hasOrigin;
+                if (subPage.startsWith("origin"))
+                  return hasFeature(config, Features.Origin);
                 if (section === "year" && subPage.startsWith("timeline"))
-                  return config.hasDate;
+                  return hasFeature(config, Features.Date);
 
                 return true;
               };
@@ -132,7 +134,9 @@ export default async function sitemap(props: {
                 return partySubPages
                   .filter((subpage) =>
                     // If there are no donors, don't index the donors page
-                    config.hasNoDonors ? subpage !== "donors" : true,
+                    !hasFeature(config, Features.Donors)
+                      ? subpage !== "donors"
+                      : true,
                   )
                   .filter(filterConditionalSubPages("party"))
                   .map((subPage) => ({
@@ -153,7 +157,9 @@ export default async function sitemap(props: {
                 return yearSubPages
                   .filter((subpage) =>
                     // If there are no donors, don't index the donors page
-                    config.hasNoDonors ? subpage !== "donors" : true,
+                    !hasFeature(config, Features.Donors)
+                      ? subpage !== "donors"
+                      : true,
                   )
                   .filter(filterConditionalSubPages("year"))
                   .map((subPage) => ({
@@ -181,7 +187,7 @@ export default async function sitemap(props: {
                   }));
               }),
               biggestDonors
-                .filter(() => !config.hasNoDonors)
+                .filter(() => hasFeature(config, Features.Donors))
                 .map((donor) => {
                   const lastDonation = lastPartyStatsDonation(
                     config,

--- a/src/components/data-export.tsx
+++ b/src/components/data-export.tsx
@@ -12,6 +12,7 @@ import { useDonationsByYears } from "@/hooks/use-api";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { isNotNullandNotUndefined } from "@/utils/array";
 import { getDonorName } from "@/utils/donor";
+import { Features, hasFeature } from "@/utils/features";
 import { AddressField, DonationField } from "@/utils/types";
 
 function escapeCSVField(field: string): string {
@@ -56,10 +57,10 @@ function generateCSV(
 ): string {
   const headers = ["Date", "Donor Name", "Receiver", "Amount", "Currency"];
 
-  if (country.hasDonorType) {
+  if (hasFeature(country, Features.DonorType)) {
     headers.push("Donor Type");
   }
-  if (country.hasOrigin) {
+  if (hasFeature(country, Features.Origin)) {
     headers.push("Country", "State");
   }
 
@@ -77,12 +78,12 @@ function generateCSV(
       country.currency,
     ];
 
-    if (country.hasDonorType) {
+    if (hasFeature(country, Features.DonorType)) {
       const donorType = donation[DonationField.DonorType];
       row.push(donorType !== undefined ? t(`donor_type.${donorType}`) : "");
     }
 
-    if (country.hasOrigin) {
+    if (hasFeature(country, Features.Origin)) {
       const address = donation[DonationField.Address];
       row.push(
         escapeCSVField(address?.[AddressField.Country] ?? ""),

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/utils/config";
 import { COUNTRY_CONFIG, getCountryName } from "@/utils/countries";
 import { countryFlags } from "@/utils/country-flags";
+import { Features, hasFeature } from "@/utils/features";
 
 import { CountrySwitch } from "./country-switch";
 
@@ -225,7 +226,7 @@ export function AppSidebar({
                     </Link>
                   </SidebarActiveMenuButton>
                 </SidebarMenuItem>
-                {countryConfig.hasDate ? (
+                {hasFeature(countryConfig, Features.Date) ? (
                   <SidebarMenuItem>
                     <SidebarActiveMenuButton
                       activeHref={`/${locale}/${countryConfig.id}/tools/bar-chart-race`}

--- a/src/components/parties/party-comparison.tsx
+++ b/src/components/parties/party-comparison.tsx
@@ -27,6 +27,7 @@ import { firstItem, lastItem } from "@/utils/array";
 import { partyColor } from "@/utils/color";
 import { QUERY_PARAM_BUILD_TS } from "@/utils/config";
 import { donationYear } from "@/utils/date";
+import { Features, hasFeature } from "@/utils/features";
 import {
   formatCompactCountryCurrency,
   formatCountryCurrency,
@@ -793,7 +794,7 @@ export const PartyComparison = ({
             </div>
           </ArticleSection>
 
-          {countryConfig.hasDonorType && (
+          {hasFeature(countryConfig, Features.DonorType) && (
             <ArticleSection
               title={tCompareParties("donor_types.title")}
               id="sec-compare-donor-types"

--- a/src/components/search/content-search.tsx
+++ b/src/components/search/content-search.tsx
@@ -21,6 +21,7 @@ import { useClientTranslations as useTranslations } from "@/hooks/use-client-tra
 import { useSearchDialog } from "@/hooks/use-search-dialog";
 import { cn } from "@/lib/utils";
 import { getParty } from "@/utils/countries";
+import { Features, hasFeature } from "@/utils/features";
 import { clientSha1 } from "@/utils/hash";
 import { serializeYears } from "@/utils/serializers";
 
@@ -193,7 +194,7 @@ const GlobalSearch = ({
     },
   ];
 
-  if (!countryConfig.hasNoDonors) {
+  if (hasFeature(countryConfig, Features.Donors)) {
     groups.push({
       id: "donors",
       title: tSearch("donors"),

--- a/src/components/table/donation-history-table.tsx
+++ b/src/components/table/donation-history-table.tsx
@@ -32,6 +32,7 @@ import { cn } from "@/lib/utils";
 import { isNotNullandNotUndefined } from "@/utils/array";
 import { getHistory } from "@/utils/data/get-history";
 import { donationYear } from "@/utils/date";
+import { Features, hasFeature } from "@/utils/features";
 import { formatCountryCurrency, formatTwoDigitDate } from "@/utils/formatter";
 import { DonationField } from "@/utils/types";
 
@@ -189,7 +190,7 @@ export const DonationHistoryTable = ({
         },
         cell: (cell) => formatCountryCurrency(locale, cell.getValue(), country),
       }),
-      country.hasExternalDonationIds
+      hasFeature(country, Features.ExternalDonationIds)
         ? columnHelper.accessor("id", {
             header: "",
             size: 50,

--- a/src/components/years/years-header.tsx
+++ b/src/components/years/years-header.tsx
@@ -16,6 +16,7 @@ import { useClientTranslations as useTranslations } from "@/hooks/use-client-tra
 import { cn } from "@/lib/utils";
 import { getParties } from "@/utils/data/get-parties";
 import { getPartiesSum } from "@/utils/data/get-parties-sum";
+import { Features, hasFeature } from "@/utils/features";
 import {
   formatCountryCurrency,
   formatNumber,
@@ -114,26 +115,28 @@ const HighscoreHeader = ({
       </h3>
       <div className="mb-4">
         <div className="flex-row space-y-2 sm:flex sm:space-y-0 sm:space-x-10">
-          {country.hasNoDonors ? null : (
+          {hasFeature(country, Features.Donors) ? (
             <MetaCard
               title={t("donation_count")}
               value={formatNumber(locale, count)}
             />
-          )}
+          ) : null}
           <MetaCard
             title={t("sum")}
             value={formatCountryCurrency(locale, sum, country)}
           />
-          {!country.hasNoDonors && showExtendedMeta && count > 1 && (
-            <MetaCard
-              title={t("average")}
-              value={formatCountryCurrency(
-                locale,
-                numbersAvg(sumNumbers, count),
-                country,
-              )}
-            />
-          )}
+          {hasFeature(country, Features.Donors) &&
+            showExtendedMeta &&
+            count > 1 && (
+              <MetaCard
+                title={t("average")}
+                value={formatCountryCurrency(
+                  locale,
+                  numbersAvg(sumNumbers, count),
+                  country,
+                )}
+              />
+            )}
         </div>
       </div>
       {withStackedBar ? (

--- a/src/utils/countries.ts
+++ b/src/utils/countries.ts
@@ -1,6 +1,8 @@
 import type { NonEmptyArray } from "@/utils/array";
 import type { StrictNamespacedTranslator } from "@/utils/translator";
 
+import { Features } from "@/utils/features";
+
 import type En from "../messages/en.json";
 import type { LambertConformalConicParams } from "./map";
 import type {
@@ -87,50 +89,53 @@ export const COUNTRIES = new Set<Country>([
 ]);
 
 export interface CountryConfig {
-  id: Country;
-  years: string[];
+  readonly id: Country;
+  readonly years: string[];
   // This is sorted by sum. Meaning first entry is the party with the highest sum of donations.
-  parties: Party[];
-  legislativeYears?: NonEmptyArray<NonEmptyArray<string>>;
-  preliminaryDataSince?: string;
-  minPublicDonationAmount: number;
-  source: { name: string; url: string };
-  currency: Currency;
-  code: CountryCode;
-  minYear: string;
-  markers: {
+  readonly parties: Party[];
+  readonly legislativeYears?: NonEmptyArray<NonEmptyArray<string>>;
+
+  // minimum year from which the data isn't complete yet
+  readonly preliminaryDataSince?: string;
+  readonly minPublicDonationAmount: number;
+  readonly source: { name: string; url: string };
+  readonly currency: Currency;
+  readonly code: CountryCode;
+
+  // Minimum year that this country has data for.
+  // Is used to e.g. skip scraping for years that are not available for a country
+  readonly minYear: string;
+
+  // markers in timeseries charts
+  readonly markers: {
     label: string;
     dates: IsoDate[];
   };
+
   // list of iso state codes
-  states: readonly string[];
-  wikiCountry: "en" | "de";
-  // true if the country has donations with a date containing more than the year
-  hasDate: boolean;
-  // true if the country has donations with information about their origin
-  hasOrigin: boolean;
-  // true if the donation dataset provides donor type information
-  hasDonorType?: boolean;
-  // true if the donation dataset provides unique ids that can be used to link to the source data
-  hasExternalDonationIds?: boolean;
-  // true if country has no donor information at all, only receiver information
-  hasNoDonors?: boolean;
+  readonly states: readonly string[];
+
+  // Which wiki language should be used when linking/load a wiki article
+  readonly wikiCountry: "en" | "de";
+
+  // features that the country has, used to determine which information can be shown
+  readonly features: number;
 
   // Include parties if they have count over this threshold or sum over the threshold.
   // Use -1 if it should only check the other condition
-  knownPartyRequirements?: {
+  readonly knownPartyRequirements?: {
     count: number;
     sum: number;
   };
 
   // Lambert Conformal Conic projection parameters for the country
-  projection?: LambertConformalConicParams;
+  readonly projection?: LambertConformalConicParams;
 
   // filter out donations by donor
-  donorFilters?: DonorFilter[];
+  readonly donorFilters?: DonorFilter[];
 
   // filtered out donation receivers
-  receiverFilters?: ReceiverFilter[];
+  readonly receiverFilters?: ReceiverFilter[];
 }
 
 export type UnloadedCountryConfig = Omit<CountryConfig, "years" | "parties">;
@@ -147,8 +152,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2022", "2023", "2024", "2025"],
       ["2026", "2027", "2028", "2029"],
     ],
-    hasOrigin: true,
-    hasDate: true,
+    features: Features.Origin | Features.Date | Features.Donors,
     minPublicDonationAmount: 35_000,
     currency: "EUR",
     source: {
@@ -196,8 +200,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2020", "2021", "2022", "2023", "2024"],
       ["2025", "2026", "2027", "2028", "2029"],
     ],
-    hasOrigin: true,
-    hasDate: true,
+    features: Features.Origin | Features.Date | Features.Donors,
     minPublicDonationAmount: 540,
     currency: "EUR",
     source: {
@@ -230,8 +233,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2020", "2021", "2022", "2023"],
       ["2024", "2025", "2026", "2027"],
     ],
-    hasOrigin: false,
-    hasDate: true,
+    features: Features.Date | Features.Donors,
     minPublicDonationAmount: 5_000,
     currency: "CHF",
     source: {
@@ -255,8 +257,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2024", "2025"],
       ["2026", "2027", "2028", "2029", "2030"],
     ],
-    hasOrigin: false,
-    hasDate: false,
+    features: Features.Donors,
     minPublicDonationAmount: 1_000,
     currency: "EUR",
     source: {
@@ -281,8 +282,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2020", "2021", "2022", "2023"],
       ["2024", "2025", "2026", "2027"],
     ],
-    hasOrigin: false,
-    hasDate: true,
+    features: Features.Date | Features.Donors,
     minPublicDonationAmount: 1,
     currency: "EUR",
     source: {
@@ -306,9 +306,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2022", "2023", "2024", "2025"],
       ["2026", "2027", "2028", "2029"],
     ],
-    hasOrigin: false,
-    hasDate: true,
-    hasDonorType: true,
+    features: Features.Date | Features.Donors | Features.DonorType,
     minPublicDonationAmount: 25, // approx 1 eur
     currency: "CZK",
     source: {
@@ -337,9 +335,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2019", "2020", "2021", "2022"],
       ["2023", "2024", "2025", "2026"],
     ],
-    hasOrigin: false,
-    hasDate: true,
-    hasExternalDonationIds: true,
+    features: Features.Date | Features.Donors | Features.ExternalDonationIds,
     minPublicDonationAmount: 1.0,
     currency: "EUR",
     source: {
@@ -367,8 +363,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2020", "2021", "2022", "2023", "2024"],
       ["2025", "2026", "2027", "2028", "2029"],
     ],
-    hasOrigin: true,
-    hasDate: false,
+    features: Features.Origin | Features.Donors,
     minPublicDonationAmount: 1,
     currency: "EUR",
     source: {
@@ -428,10 +423,11 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2020", "2021", "2022", "2023", "2024"],
       ["2025", "2026", "2027", "2028", "2029"],
     ],
-    hasDate: true,
-    hasOrigin: false,
-    hasDonorType: true,
-    hasExternalDonationIds: true,
+    features:
+      Features.Date |
+      Features.Donors |
+      Features.DonorType |
+      Features.ExternalDonationIds,
     minPublicDonationAmount: 1000,
     currency: "GBP",
     wikiCountry: "en",
@@ -479,9 +475,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2023", "2024", "2025"],
       ["2026", "2027", "2028"],
     ],
-    hasOrigin: false,
-    hasDate: true,
-    hasDonorType: true,
+    features: Features.Date | Features.Donors | Features.DonorType,
     minPublicDonationAmount: 1,
     currency: "AUD",
     source: {
@@ -602,8 +596,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2023"],
       ["2024", "2025", "2026", "2027"],
     ],
-    hasOrigin: false,
-    hasDate: false,
+    features: Features.Donors,
     minPublicDonationAmount: 400,
     currency: "RSD",
     source: {
@@ -626,8 +619,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
     id: Country.croatia,
     minYear: "2019",
     preliminaryDataSince: "2025",
-    hasOrigin: false,
-    hasDate: true,
+    features: Features.Date | Features.Donors,
     minPublicDonationAmount: 1,
     currency: "EUR",
     source: {
@@ -661,8 +653,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
       ["2022", "2023", "2024", "2025"],
       ["2026", "2027", "2028", "2029"],
     ],
-    hasOrigin: true,
-    hasDate: true,
+    features: Features.Origin | Features.Date | Features.Donors,
     minPublicDonationAmount: 500,
     currency: "CAD",
     source: {
@@ -711,9 +702,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
     id: Country.georgia,
     minYear: "2011",
     preliminaryDataSince: "2026",
-    hasOrigin: false,
-    hasDate: true,
-    hasDonorType: true,
+    features: Features.Date | Features.Donors | Features.DonorType,
     minPublicDonationAmount: 1,
     currency: "GEL",
     source: {
@@ -748,9 +737,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
     id: Country.norway,
     minYear: "2014",
     preliminaryDataSince: "2024",
-    hasOrigin: false,
-    hasDate: false,
-    hasDonorType: false,
+    features: Features.Donors,
     minPublicDonationAmount: 500,
     currency: "NOK",
     source: {
@@ -775,9 +762,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
     id: Country.ukraine,
     minYear: "2020",
     preliminaryDataSince: "2021",
-    hasOrigin: false,
-    hasDate: true,
-    hasDonorType: false,
+    features: Features.Date | Features.Donors,
     minPublicDonationAmount: 10,
     currency: "UAH",
     source: {
@@ -797,10 +782,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
     id: Country.france,
     minYear: "2010",
     preliminaryDataSince: "2024",
-    hasOrigin: false,
-    hasDate: false,
-    hasDonorType: false,
-    hasNoDonors: true,
+    features: Features.None,
     minPublicDonationAmount: 7500,
     currency: "EUR",
     source: {
@@ -836,10 +818,7 @@ export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
     id: Country.sweden,
     minYear: "2018",
     preliminaryDataSince: "2024",
-    hasOrigin: false,
-    hasDate: false,
-    hasDonorType: false,
-    hasNoDonors: true,
+    features: Features.None,
     minPublicDonationAmount: 1,
     currency: "SEK",
     source: {

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -1,0 +1,23 @@
+import type { CountryConfig } from "@/utils/countries";
+
+export const enum Features {
+  // default value, no special features supported
+  None = 0,
+  // has donations with a date containing more than the year
+  Date = 1 << 0,
+  // has donations with information about their origin
+  Origin = 1 << 1,
+  // the donations that specify donor type information
+  DonorType = 1 << 2,
+  // has donations with unique ids that can be used to link to the source data
+  ExternalDonationIds = 1 << 3,
+  // has donations with donor names
+  Donors = 1 << 4,
+}
+
+export const hasFeature = (
+  country: Pick<CountryConfig, "features">,
+  feature: Features,
+): boolean => {
+  return (country.features & feature) === feature;
+};

--- a/src/utils/party.ts
+++ b/src/utils/party.ts
@@ -1,6 +1,8 @@
 import type { CountryConfig } from "@/utils/countries";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 
+import { Features, hasFeature } from "@/utils/features";
+
 export const yearPartiesHaveYearOnlyDonations = (
   partySums: PartyYearsSums,
   years: string[],
@@ -23,7 +25,7 @@ export const canShowYearsTimeline = (
   );
 
   if (
-    !countryConfig.hasDate ||
+    !hasFeature(countryConfig, Features.Date) ||
     // if we have years with year donations, we consider this as country without date for the picked range
     containsYearOnlyDonations
   ) {

--- a/tasks/fake-data/generate-fake-data.ts
+++ b/tasks/fake-data/generate-fake-data.ts
@@ -12,6 +12,7 @@ import type {
 
 import { COUNTRY_CONFIG } from "@/utils/countries";
 import { fillYears } from "@/utils/date";
+import { Features, hasFeature } from "@/utils/features";
 import { AddressField, DonationField, RelationKind } from "@/utils/types";
 
 import type { ExtractedYearData, PartyConfig } from "../load-data/data-loader";
@@ -52,10 +53,11 @@ class FakeDataLoader extends DataLoader {
   }
 
   // Fake donorMeta with the test donor as they need a Wikipedia article
-  public readonly donorMeta: DonorMetaDefinition = COUNTRY_CONFIG[this.country]
-    .hasNoDonors
-    ? { donors: {}, relations: [] }
-    : {
+  public readonly donorMeta: DonorMetaDefinition = hasFeature(
+    COUNTRY_CONFIG[this.country],
+    Features.Donors,
+  )
+    ? {
         donors: {
           [DONOR_WITH_WIKIPEDIA_ARTICLE]: {
             wiki: 12345, // Fake wiki ID for testing
@@ -67,7 +69,8 @@ class FakeDataLoader extends DataLoader {
             [DONOR_WITH_REL_B, RelationKind.family],
           ],
         ],
-      };
+      }
+    : { donors: {}, relations: [] };
 
   private pickRandomParty(): string {
     const partyKeys = Object.keys(this.parties);
@@ -160,7 +163,7 @@ class FakeDataLoader extends DataLoader {
           [DonationField.Receiver]: partyName,
           [DonationField.Address]:
             // if country has origin, create a state donation for the first donation
-            countryConfig.hasOrigin && j === 0
+            hasFeature(countryConfig, Features.Origin) && j === 0
               ? {
                   [AddressField.Country]: isEu ? "DE" : countryConfig.code,
                   [AddressField.State]: isEu

--- a/tasks/social-images/generate-images.test.tsx
+++ b/tasks/social-images/generate-images.test.tsx
@@ -16,6 +16,7 @@ import type { Donation } from "@/utils/types";
 
 import { COUNTRIES } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { Features, hasFeature } from "@/utils/features";
 import { getBiggestDonors } from "@/utils/loader/biggest-donors";
 import { getPartyYearsSums } from "@/utils/loader/party-years-sums";
 import { CONST_LOCALES } from "@/utils/locales";
@@ -193,7 +194,7 @@ describe.each(CONST_LOCALES.map((locale) => ({ locale })))(
 
         it(`renders biggest donors images`, async () => {
           // if there are no donors, skip rendering donor images
-          if (countryConfig.hasNoDonors) return;
+          if (!hasFeature(countryConfig, Features.Donors)) return;
 
           for (const donor of biggestDonors) {
             const png = await renderComponent(


### PR DESCRIPTION
## Description

Extracts country feature bool fields into separate field using bitmasks. This cleans the whole country config up a bit.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Data update/addition
- [ ] Documentation update
- [x] Refactoring

## Testing

- [x] Unit tests pass (`pnpm test:unit`)
- [x] Lint passes (`pnpm lint`)
- [x] E2E tests pass (`pnpm test:e2e`) - if UI changes
