### PR TITLE
refactor: split rarely used data from country config

### DIFF
--- a/src/app/[locale]/[country]/donor/[donorId]/donor-client-page.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/donor-client-page.tsx
@@ -2,7 +2,8 @@
 import { useLocale } from "next-intl";
 import { notFound } from "next/navigation";
 
-import type { Country, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Country } from "@/utils/countries";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { DonationStackedTimeseriesChart } from "@/components/charts/donation-sum-chart";

--- a/src/app/[locale]/[country]/donor/[donorId]/donor-page-head.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/donor-page-head.tsx
@@ -2,7 +2,8 @@
 import { HatGlasses, Info, Lock } from "lucide-react";
 import { useLocale } from "next-intl";
 
-import type { Countries, Country, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Countries, Country } from "@/utils/countries";
 import type { Donation, DonorMeta, ReceiverId } from "@/utils/types";
 
 import { AbsoluteMultipleColorsGradient } from "@/components/absolute-multiple-colors-gradient";

--- a/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars-content.tsx
+++ b/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars-content.tsx
@@ -3,6 +3,7 @@ import { useLocale } from "next-intl";
 import { parseAsString, useQueryState } from "nuqs";
 import { useMemo } from "react";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { NonEmptyArray } from "@/utils/array";
 
 import { EChartsRacingBars } from "@/components/charts/echarts-racing-bars";
@@ -10,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { YearRangeSelector } from "@/components/years/year-range-selector";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { firstItem, lastItem } from "@/utils/array";
-import { type CountryConfig, getCountryName } from "@/utils/countries";
+import { getCountryName } from "@/utils/countries";
 import { formatYearsRange } from "@/utils/formatter";
 import { type Donation, DonationField } from "@/utils/types";
 

--- a/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars.tsx
+++ b/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Suspense } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { useDonationsByYears } from "@/hooks/use-api";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";

--- a/src/app/[locale]/[country]/transparency/page.tsx
+++ b/src/app/[locale]/[country]/transparency/page.tsx
@@ -3,13 +3,8 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 
-import {
-  AggregatedDonorsList,
-  FilteredDonorsList,
-  FilteredReceiversList,
-  NormalizedReceiversList,
-} from "@/app/[locale]/[country]/transparency/transparency-list";
-import { Article, ArticleSection } from "@/components/layout/article";
+import { DynamicTransparencyPageContent } from "@/app/[locale]/[country]/transparency/transparency-list";
+import { Article } from "@/components/layout/article";
 import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { LOCALES } from "@/utils/locales";
@@ -65,53 +60,32 @@ export default async function Page(
 
   return (
     <Article title={tTransparency("title")}>
-      {countryConfig.receiverFilters ? (
-        <ArticleSection title={tTransparency("section.filtered_receivers")}>
-          <p>{tTransparency("filtered_receivers.p0")}</p>
-          <ul className="list-inside list-disc text-sm">
-            {countryConfig.receiverFilters.map((filter, idx) => (
-              <li key={`filter-${idx}`}>
-                <span className="rounded bg-neutral-200 px-1 py-0.5 font-mono dark:bg-neutral-900">
-                  {filter.toString()}
-                </span>
-              </li>
-            ))}
-          </ul>
-          <p>{tTransparency("filtered_receivers.p1")}</p>
-          <FilteredReceiversList countryConfig={countryConfig} />
-        </ArticleSection>
-      ) : null}
-
-      {countryConfig.donorFilters ? (
-        <ArticleSection title={tTransparency("section.filtered_donors")}>
-          <p>{tTransparency("filtered_donors.p0")}</p>
-          <ul className="list-inside list-disc text-sm">
-            {countryConfig.donorFilters.map((filter, idx) => (
-              <li key={`filter-${idx}`}>
-                <span className="rounded bg-neutral-200 px-1 py-0.5 font-mono dark:bg-neutral-900">
-                  {filter.toString()}
-                </span>
-              </li>
-            ))}
-          </ul>
-          <p>{tTransparency("filtered_donors.p1")}</p>
-          <FilteredDonorsList countryConfig={countryConfig} />
-        </ArticleSection>
-      ) : null}
-
-      <NormalizedReceiversList
-        title={tTransparency("receivers.title")}
-        description={tTransparency("receivers.p0", {
-          country: getCountryName(countryConfig, tCountries),
-        })}
+      <DynamicTransparencyPageContent
         countryConfig={countryConfig}
+        texts={{
+          filteredReceivers: {
+            title: tTransparency("section.filtered_receivers"),
+            p0: tTransparency("filtered_receivers.p0"),
+            p1: tTransparency("filtered_receivers.p1"),
+          },
+          filteredDonors: {
+            title: tTransparency("section.filtered_donors"),
+            p0: tTransparency("filtered_donors.p0"),
+            p1: tTransparency("filtered_donors.p1"),
+          },
+          normalizedReceivers: {
+            title: tTransparency("receivers.title"),
+            p0: tTransparency("receivers.p0", {
+              country: getCountryName(countryConfig, tCountries),
+            }),
+          },
+          aggregatedDonors: {
+            title: tTransparency("section.aggregated"),
+            p0: tTransparency("p0"),
+            p1: tTransparency("p1"),
+          },
+        }}
       />
-
-      <ArticleSection title={tTransparency("section.aggregated")}>
-        <p>{tTransparency("p0")}</p>
-        <p>{tTransparency("p1")}</p>
-        <AggregatedDonorsList countryConfig={countryConfig} />
-      </ArticleSection>
     </Article>
   );
 }

--- a/src/app/[locale]/[country]/transparency/transparency-list.tsx
+++ b/src/app/[locale]/[country]/transparency/transparency-list.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useLocale } from "next-intl";
+import dynamic from "next/dynamic";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { UseNormalizedData } from "@/hooks/use-api";
+import type { CountryConfig } from "@/types/country-config";
 
 import { FormatAnd } from "@/components/formatter";
 import { ArticleSection } from "@/components/layout/article";
@@ -10,17 +12,125 @@ import Loading from "@/components/loading/loading";
 import { useNormalized } from "@/hooks/use-api";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 
-export const FilteredReceiversList = ({
+// We use a dynamic component as we don't care about server rendering + client hydrating this content
+export const DynamicTransparencyPageContent = dynamic(
+  () => Promise.resolve(TransparencyPageContent),
+  { ssr: false },
+);
+
+const TransparencyPageContent = ({
   countryConfig,
+  texts,
 }: {
   countryConfig: CountryConfig;
+  texts: {
+    filteredReceivers: { title: string; p0: string; p1: string };
+    filteredDonors: { title: string; p0: string; p1: string };
+    normalizedReceivers: { title: string; p0: string };
+    aggregatedDonors: { title: string; p0: string; p1: string };
+  };
 }) => {
   const tData = useTranslations("data");
-  const locale = useLocale();
   const { data, error, isLoading } = useNormalized(countryConfig);
 
   if (isLoading) return <Loading />;
   if (error || !data) return tData("error");
+
+  return (
+    <>
+      <TransparencyReceiverFiltersList
+        data={data}
+        title={texts.filteredReceivers.title}
+        p0={texts.filteredReceivers.p0}
+        p1={texts.filteredReceivers.p1}
+      />
+
+      <TransparencyDonorFiltersList
+        data={data}
+        title={texts.filteredDonors.title}
+        p0={texts.filteredDonors.p0}
+        p1={texts.filteredDonors.p1}
+      />
+
+      <NormalizedReceiversList
+        data={data}
+        title={texts.normalizedReceivers.title}
+        description={texts.normalizedReceivers.p0}
+      />
+
+      <ArticleSection title={texts.aggregatedDonors.title}>
+        <p>{texts.aggregatedDonors.p0}</p>
+        <p>{texts.aggregatedDonors.p1}</p>
+        <AggregatedDonorsList data={data} />
+      </ArticleSection>
+    </>
+  );
+};
+
+const TransparencyReceiverFiltersList = ({
+  data,
+  title,
+  p0,
+  p1,
+}: {
+  data: UseNormalizedData;
+  title: string;
+  p0: string;
+  p1: string;
+}) => {
+  if (!data.receiverFilters) return null;
+
+  return (
+    <ArticleSection title={title}>
+      <p>{p0}</p>
+      <ul className="list-inside list-disc text-sm">
+        {data.receiverFilters.map((filter, idx) => (
+          <li key={`filter-${idx}`}>
+            <span className="rounded bg-neutral-200 px-1 py-0.5 font-mono dark:bg-neutral-900">
+              {filter.toString()}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p>{p1}</p>
+      <FilteredReceiversList data={data} />
+    </ArticleSection>
+  );
+};
+
+const TransparencyDonorFiltersList = ({
+  data,
+  title,
+  p0,
+  p1,
+}: {
+  data: UseNormalizedData;
+  title: string;
+  p0: string;
+  p1: string;
+}) => {
+  if (!data.donorFilters) return null;
+
+  return (
+    <ArticleSection title={title}>
+      <p>{p0}</p>
+      <ul className="list-inside list-disc text-sm">
+        {data.donorFilters.map((filter, idx) => (
+          <li key={`filter-${idx}`}>
+            <span className="rounded bg-neutral-200 px-1 py-0.5 font-mono dark:bg-neutral-900">
+              {filter.toString()}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p>{p1}</p>
+      <FilteredDonorsList data={data} />
+    </ArticleSection>
+  );
+};
+
+const FilteredReceiversList = ({ data }: { data: UseNormalizedData }) => {
+  const locale = useLocale();
 
   return (
     <p className="text-sm">
@@ -34,17 +144,8 @@ export const FilteredReceiversList = ({
   );
 };
 
-export const FilteredDonorsList = ({
-  countryConfig,
-}: {
-  countryConfig: CountryConfig;
-}) => {
-  const tData = useTranslations("data");
+const FilteredDonorsList = ({ data }: { data: UseNormalizedData }) => {
   const locale = useLocale();
-  const { data, error, isLoading } = useNormalized(countryConfig);
-
-  if (isLoading) return <Loading />;
-  if (error || !data) return tData("error");
 
   return (
     <p className="text-sm">
@@ -58,20 +159,16 @@ export const FilteredDonorsList = ({
   );
 };
 
-export const NormalizedReceiversList = ({
+const NormalizedReceiversList = ({
+  data,
   title,
   description,
-  countryConfig,
 }: {
+  data: UseNormalizedData;
   title: string;
   description: string;
-  countryConfig: CountryConfig;
 }) => {
   const locale = useLocale();
-  const { data, error, isLoading } = useNormalized(countryConfig);
-
-  if (isLoading) return null; // Don't show anything while loading for this conditional section? Or maybe separate loading state?
-  if (error || !data) return null;
 
   if (!data.normalizedReceivers.length) return null;
 
@@ -102,17 +199,8 @@ export const NormalizedReceiversList = ({
   );
 };
 
-export const AggregatedDonorsList = ({
-  countryConfig,
-}: {
-  countryConfig: CountryConfig;
-}) => {
-  const tData = useTranslations("data");
+const AggregatedDonorsList = ({ data }: { data: UseNormalizedData }) => {
   const locale = useLocale();
-  const { data, error, isLoading } = useNormalized(countryConfig);
-
-  if (isLoading) return <Loading />;
-  if (error || !data) return tData("error");
 
   return (
     <ul data-testid="transparency-list" className="text-sm">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 
-import type { Country, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Country } from "@/utils/countries";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";

--- a/src/components/charts/donation-per-month-chart.tsx
+++ b/src/components/charts/donation-per-month-chart.tsx
@@ -3,6 +3,7 @@ import type { BarSeriesOption, EChartsOption } from "echarts";
 
 import { useLocale } from "next-intl";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";
@@ -11,7 +12,7 @@ import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { isNotNullandNotUndefined } from "@/utils/array";
 import { partyColor } from "@/utils/color";
-import { type CountryConfig, getParty } from "@/utils/countries";
+import { getParty } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
 import { buildElectionTimelineMarkArea } from "@/utils/election-marker";
 import {

--- a/src/components/charts/donation-stacked-years.tsx
+++ b/src/components/charts/donation-stacked-years.tsx
@@ -8,7 +8,7 @@ import type {
 import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 
 import { useChart } from "@/hooks/use-chart";

--- a/src/components/charts/donation-state-map.tsx
+++ b/src/components/charts/donation-state-map.tsx
@@ -3,7 +3,8 @@ import type { EChartsOption } from "echarts";
 
 import { useLocale } from "next-intl";
 
-import type { Countries, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Countries } from "@/utils/countries";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import { useChart } from "@/hooks/use-chart";

--- a/src/components/charts/donation-state-sankey.tsx
+++ b/src/components/charts/donation-state-sankey.tsx
@@ -4,12 +4,13 @@ import type { SankeyNodeItemOption } from "echarts/types/src/chart/sankey/Sankey
 
 import { useLocale } from "next-intl";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { partyColor } from "@/utils/color";
-import { Country, type CountryConfig } from "@/utils/countries";
+import { Country } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
 import { formatCountryCurrency, formatPartyShortName } from "@/utils/formatter";
 import { sourceId, targetId } from "@/utils/graph";

--- a/src/components/charts/donation-sum-chart.tsx
+++ b/src/components/charts/donation-sum-chart.tsx
@@ -3,6 +3,7 @@ import type { EChartsOption, LineSeriesOption } from "echarts";
 
 import { useLocale } from "next-intl";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";
@@ -11,7 +12,7 @@ import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { isNotNullandNotUndefined } from "@/utils/array";
 import { partyColor } from "@/utils/color";
-import { type CountryConfig, getParty } from "@/utils/countries";
+import { getParty } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
 import { buildElectionTimelineMarkArea } from "@/utils/election-marker";
 import {

--- a/src/components/charts/donation-year-scatter-plot.tsx
+++ b/src/components/charts/donation-year-scatter-plot.tsx
@@ -8,6 +8,7 @@ import type {
 
 import { useLocale } from "next-intl";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";
@@ -17,7 +18,7 @@ import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { isNotNullandNotUndefined } from "@/utils/array";
 import { partyColor } from "@/utils/color";
-import { type CountryConfig, getParty } from "@/utils/countries";
+import { getParty } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
 import { formatCountryCurrency, formatPartyShortName } from "@/utils/formatter";
 import { DonationField } from "@/utils/types";

--- a/src/components/charts/donations-pie-chart.tsx
+++ b/src/components/charts/donations-pie-chart.tsx
@@ -5,17 +5,14 @@ import type { TreemapSeriesNodeItemOption } from "echarts/types/src/chart/treema
 import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ReceiverId } from "@/utils/types";
 
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { partyColor } from "@/utils/color";
-import {
-  type CountryConfig,
-  getCountryName,
-  getParty,
-} from "@/utils/countries";
+import { getCountryName, getParty } from "@/utils/countries";
 import { formatCountryCurrency, formatYearsRange } from "@/utils/formatter";
 
 import { ExpandableReactEchart } from "./expandable-react-echart";

--- a/src/components/charts/echarts-racing-bars.tsx
+++ b/src/components/charts/echarts-racing-bars.tsx
@@ -4,7 +4,8 @@ import type { BarSeriesOption, EChartsOption } from "echarts";
 import { Download, Pause, Play, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { CountryConfig, Currency } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Currency } from "@/utils/countries";
 import type { ConstLocale } from "@/utils/locales";
 
 import { ExpandableReactEchart } from "@/components/charts/expandable-react-echart";

--- a/src/components/charts/expandable-react-echart.tsx
+++ b/src/components/charts/expandable-react-echart.tsx
@@ -5,7 +5,7 @@ import { Expand, X, ZoomOut } from "lucide-react";
 import { useLocale } from "next-intl";
 import { type JSX, useCallback, useRef, useState } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { PageLogo } from "@/components/layout/page-logo";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";

--- a/src/components/charts/geojson-loader.tsx
+++ b/src/components/charts/geojson-loader.tsx
@@ -7,7 +7,7 @@ import { VisualMapComponent } from "echarts/components";
 import * as echarts from "echarts/core";
 import { useEffect, useState } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { Country } from "@/utils/countries";
 

--- a/src/components/charts/loading-donation-years-treemap.tsx
+++ b/src/components/charts/loading-donation-years-treemap.tsx
@@ -5,6 +5,7 @@ import type { TreemapSeriesNodeItemOption } from "echarts/types/src/chart/treema
 import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";
@@ -13,7 +14,7 @@ import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { isNotNullandNotUndefined } from "@/utils/array";
 import { partyColor } from "@/utils/color";
-import { type CountryConfig, getParty } from "@/utils/countries";
+import { getParty } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
 import { getDonorName } from "@/utils/donor";
 import { formatCountryCurrency } from "@/utils/formatter";

--- a/src/components/charts/loading-donor-receiver-histogram.tsx
+++ b/src/components/charts/loading-donor-receiver-histogram.tsx
@@ -4,7 +4,7 @@ import type { CallbackDataParams } from "echarts/types/dist/shared";
 
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";

--- a/src/components/charts/loading-donor-types-treemap.tsx
+++ b/src/components/charts/loading-donor-types-treemap.tsx
@@ -5,6 +5,7 @@ import type { TreemapSeriesNodeItemOption } from "echarts/types/src/chart/treema
 import { useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";
@@ -12,7 +13,7 @@ import { useDonationsByParty } from "@/hooks/use-api";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { donorTypeColor, partyColor } from "@/utils/color";
-import { type CountryConfig, getParty } from "@/utils/countries";
+import { getParty } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
 import { formatCountryCurrency } from "@/utils/formatter";
 import { clientSha1 } from "@/utils/hash";

--- a/src/components/charts/stacked-party-line.tsx
+++ b/src/components/charts/stacked-party-line.tsx
@@ -1,3 +1,4 @@
+import type { CountryConfig } from "@/types/country-config";
 import type {
   PartyStats,
   PartyYearsSums,
@@ -8,7 +9,7 @@ import type { ReceiverId } from "@/utils/types";
 import { AbsoluteMultipleColorsGradient } from "@/components/absolute-multiple-colors-gradient";
 import { cn } from "@/lib/utils";
 import { partyColor } from "@/utils/color";
-import { type CountryConfig, getParty } from "@/utils/countries";
+import { getParty } from "@/utils/countries";
 import { formatCountryCurrency } from "@/utils/formatter";
 
 export const StackedPartyDonations = ({

--- a/src/components/data-export.tsx
+++ b/src/components/data-export.tsx
@@ -3,7 +3,7 @@ import type { Messages, createTranslator } from "next-intl";
 
 import { DownloadIcon } from "lucide-react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { StrictNamespacedTranslator } from "@/utils/translator";
 import type { Donation } from "@/utils/types";
 

--- a/src/components/donations/biggest-donations-hero.tsx
+++ b/src/components/donations/biggest-donations-hero.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation } from "@/utils/types";
 
 import { DonorLink } from "@/components/donors/donor-link";

--- a/src/components/donations/donation-history-item.tsx
+++ b/src/components/donations/donation-history-item.tsx
@@ -1,6 +1,6 @@
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ReceiverId } from "@/utils/types";
 
 import { DonorLink } from "@/components/donors/donor-link";

--- a/src/components/donations/donation-origin-visual.tsx
+++ b/src/components/donations/donation-origin-visual.tsx
@@ -2,6 +2,7 @@
 import { Map, Workflow } from "lucide-react";
 import { useState } from "react";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party } from "@/utils/types";
 
 import { DonationStateMap } from "@/components/charts/donation-state-map";
@@ -10,7 +11,7 @@ import { DynamicGeoJsonLoader } from "@/components/charts/dynamic-geojson-loader
 import { NavigationTab } from "@/components/layout/navigation-tab";
 import { TabList } from "@/components/tabs";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
-import { type CountryConfig, getCountryName } from "@/utils/countries";
+import { getCountryName } from "@/utils/countries";
 
 type ChartType = "map" | "sankey";
 const DEFAULT_TYPE: ChartType = "map";

--- a/src/components/donations/donation-origin.tsx
+++ b/src/components/donations/donation-origin.tsx
@@ -2,6 +2,7 @@
 import { useLocale } from "next-intl";
 import { useState } from "react";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { OriginPartySum } from "@/utils/data/get-origin-donations";
 import type { Donation, Party } from "@/utils/types";
 
@@ -17,7 +18,7 @@ import Loading from "@/components/loading/loading";
 import { useDonationsByParty, useDonationsByYears } from "@/hooks/use-api";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { isNotNullandNotUndefined } from "@/utils/array";
-import { Country, type CountryConfig, getCountryName } from "@/utils/countries";
+import { Country, getCountryName } from "@/utils/countries";
 import { getOriginDonations } from "@/utils/data/get-origin-donations";
 import { formatCountryCurrency, formatYearsRange } from "@/utils/formatter";
 import { AddressField, DonationField } from "@/utils/types";

--- a/src/components/donations/external-donation-link.tsx
+++ b/src/components/donations/external-donation-link.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, PropsWithChildren } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { Country } from "@/utils/countries";
 

--- a/src/components/donations/noninteractable-ranking-item.tsx
+++ b/src/components/donations/noninteractable-ranking-item.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 
 import { RankBadge } from "@/components/donations/ranking-item";

--- a/src/components/donations/origin-donations-item.tsx
+++ b/src/components/donations/origin-donations-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation } from "@/utils/types";
 
 import { CurrencyRankingItem } from "@/components/donations/ranking-item";

--- a/src/components/donations/party-donation-history.tsx
+++ b/src/components/donations/party-donation-history.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";

--- a/src/components/donations/ranking-item-line.tsx
+++ b/src/components/donations/ranking-item-line.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 
 import { cn } from "@/lib/utils";

--- a/src/components/donations/ranking-item.tsx
+++ b/src/components/donations/ranking-item.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren, ReactNode } from "react";
 import { ChevronRight } from "lucide-react";
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { PercentageHint } from "@/components/percentage-hint";
 import { formatCountryCurrency } from "@/utils/formatter";

--- a/src/components/donors/donor-donations-detail.tsx
+++ b/src/components/donors/donor-donations-detail.tsx
@@ -2,7 +2,7 @@
 import { useLocale } from "next-intl";
 import { useEffect } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { RankingItemLine } from "@/components/donations/ranking-item-line";

--- a/src/components/donors/donor-link.tsx
+++ b/src/components/donors/donor-link.tsx
@@ -5,7 +5,7 @@ import type { PropsWithChildren } from "react";
 import { useLocale } from "next-intl";
 import Link from "next/link";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { DonorName } from "@/components/donors/donor-name";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";

--- a/src/components/donors/donor-overview-item.tsx
+++ b/src/components/donors/donor-overview-item.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { ArrowRight } from "lucide-react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { CurrencyRankingItem } from "@/components/donations/ranking-item";
 import { DonorLink } from "@/components/donors/donor-link";

--- a/src/components/donors/donor-overview-list.tsx
+++ b/src/components/donors/donor-overview-list.tsx
@@ -2,7 +2,7 @@
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useRef, useState } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";

--- a/src/components/donors/donor-year-overview.tsx
+++ b/src/components/donors/donor-year-overview.tsx
@@ -2,7 +2,7 @@
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useRef, useState } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";

--- a/src/components/donors/donors-hero.tsx
+++ b/src/components/donors/donors-hero.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
 import type { ConstLocale } from "@/utils/locales";
 

--- a/src/components/donors/related-donor-chip.tsx
+++ b/src/components/donors/related-donor-chip.tsx
@@ -4,7 +4,7 @@ import type { JSX } from "react";
 
 import { BriefcaseBusiness, Building2, Landmark } from "lucide-react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 

--- a/src/components/donors/years-donor-histogram-text.tsx
+++ b/src/components/donors/years-donor-histogram-text.tsx
@@ -2,7 +2,7 @@
 import { useLocale } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { Donation, Party } from "@/utils/types";
 

--- a/src/components/donors/years-donor-page-text.tsx
+++ b/src/components/donors/years-donor-page-text.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party } from "@/utils/types";
 
 import { DonorLink } from "@/components/donors/donor-link";

--- a/src/components/external-thanks.tsx
+++ b/src/components/external-thanks.tsx
@@ -1,6 +1,6 @@
 import { getTranslations } from "next-intl/server";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 
 import { FormatAnd } from "@/components/formatter";

--- a/src/components/history-component.tsx
+++ b/src/components/history-component.tsx
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { DonationHistoryItem } from "@/components/donations/donation-history-item";
 import { getMostRecent } from "@/utils/loader/most-recent";

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -16,7 +16,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 
-import type { Country, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Country } from "@/utils/countries";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
 
 import { Github } from "@/components/icons/Github";

--- a/src/components/layout/country-footer.tsx
+++ b/src/components/layout/country-footer.tsx
@@ -2,7 +2,7 @@
 import { useLocale } from "next-intl";
 import Link from "next/link";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { formatDate } from "@/utils/formatter";

--- a/src/components/layout/detected-country.tsx
+++ b/src/components/layout/detected-country.tsx
@@ -2,7 +2,8 @@
 import { ArrowUpRight } from "lucide-react";
 import { useLocale } from "next-intl";
 
-import type { CountryCode, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { CountryCode } from "@/utils/countries";
 
 import { useDetectedCountry } from "@/hooks/use-api";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";

--- a/src/components/loading/loading-top-year-donations-item-detail.tsx
+++ b/src/components/loading/loading-top-year-donations-item-detail.tsx
@@ -2,7 +2,7 @@
 import { useLocale } from "next-intl";
 import { useEffect, useMemo, useRef } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { RankingItemLine } from "@/components/donations/ranking-item-line";

--- a/src/components/loading/loading-top-year-donations-item.tsx
+++ b/src/components/loading/loading-top-year-donations-item.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight } from "lucide-react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { Donation, ReceiverId } from "@/utils/types";
 

--- a/src/components/loading/loading-year-bars-page-text.tsx
+++ b/src/components/loading/loading-year-bars-page-text.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import { FormatAnd } from "@/components/formatter";

--- a/src/components/loading/loading-year-timeline-year-text.tsx
+++ b/src/components/loading/loading-year-timeline-year-text.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";

--- a/src/components/loading/loading-year-timeseries-text.tsx
+++ b/src/components/loading/loading-year-timeseries-text.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";

--- a/src/components/parties/part-donor-type-text.tsx
+++ b/src/components/parties/part-donor-type-text.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/utils/types";
 
 import { RankBadge } from "@/components/donations/ranking-item";

--- a/src/components/parties/parties-hero.tsx
+++ b/src/components/parties/parties-hero.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from "react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { Party } from "@/utils/types";
 

--- a/src/components/parties/party-comparison.tsx
+++ b/src/components/parties/party-comparison.tsx
@@ -10,8 +10,8 @@ import { parseAsArrayOf, parseAsString, useQueryState } from "nuqs";
 import { useMemo } from "react";
 
 import type { DonationsDocumentWithoutDonorIds } from "@/lib/api/donations-document";
+import type { CountryConfig } from "@/types/country-config";
 import type { NonEmptyArray } from "@/utils/array";
-import type { CountryConfig } from "@/utils/countries";
 import type { RootTranslator } from "@/utils/translator";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 

--- a/src/components/parties/party-donor-page-text.tsx
+++ b/src/components/parties/party-donor-page-text.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation, Party } from "@/utils/types";
 
 import { DonorLink } from "@/components/donors/donor-link";

--- a/src/components/parties/party-dot.tsx
+++ b/src/components/parties/party-dot.tsx
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ReceiverId } from "@/utils/types";
 
 import { cn } from "@/lib/utils";

--- a/src/components/parties/party-link.tsx
+++ b/src/components/parties/party-link.tsx
@@ -3,12 +3,13 @@ import type { PropsWithChildren } from "react";
 
 import Link from "next/link";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { ReceiverId } from "@/utils/types";
 
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { cn } from "@/lib/utils";
-import { type CountryConfig, getParty } from "@/utils/countries";
+import { getParty } from "@/utils/countries";
 
 export const PartyLink = ({
   locale,

--- a/src/components/parties/party-timeline-text.tsx
+++ b/src/components/parties/party-timeline-text.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useLocale } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/utils/types";
 
 import Loading from "@/components/loading/loading";

--- a/src/components/parties/text-party-link.tsx
+++ b/src/components/parties/text-party-link.tsx
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { ReceiverId } from "@/utils/types";
 

--- a/src/components/search/content-search.tsx
+++ b/src/components/search/content-search.tsx
@@ -6,7 +6,8 @@ import { useLocale } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
-import type { Country, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Country } from "@/utils/countries";
 import type { Party, ReceiverId } from "@/utils/types";
 
 import { PartyDot } from "@/components/parties/party-dot";

--- a/src/components/table/donation-history-table.tsx
+++ b/src/components/table/donation-history-table.tsx
@@ -16,7 +16,7 @@ import {
 import { useLocale } from "next-intl";
 import { useMemo, useRef, useState } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { HistoryEntry } from "@/utils/data/get-history";
 import type { Donation } from "@/utils/types";
 

--- a/src/components/wiki-quote.tsx
+++ b/src/components/wiki-quote.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { UnloadedCountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { useWikipediaByPageId } from "@/hooks/use-api";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
@@ -20,7 +20,7 @@ export const WikiQuote = ({
   country,
 }: {
   pageId: number;
-  country: UnloadedCountryConfig;
+  country: CountryConfig;
 }) => {
   const t = useTranslations("data");
   const { data, error, isLoading } = useWikipediaByPageId(country, pageId);

--- a/src/components/years/top-party-year-donations.tsx
+++ b/src/components/years/top-party-year-donations.tsx
@@ -2,7 +2,7 @@
 import { useLocale } from "next-intl";
 import { useState } from "react";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartySum } from "@/utils/data/get-parties-sum";
 import type { Donation } from "@/utils/types";
 

--- a/src/components/years/year-range-selector.tsx
+++ b/src/components/years/year-range-selector.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { Button } from "@/components/ui/button";
 import {

--- a/src/components/years/years-cards.tsx
+++ b/src/components/years/years-cards.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 

--- a/src/components/years/years-footer-nav.tsx
+++ b/src/components/years/years-footer-nav.tsx
@@ -2,7 +2,7 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import Link from "next/link";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";

--- a/src/components/years/years-header.tsx
+++ b/src/components/years/years-header.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren } from "react";
 
 import Link from "next/link";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 import type { Party } from "@/utils/types";

--- a/src/hooks/use-api.ts
+++ b/src/hooks/use-api.ts
@@ -8,11 +8,10 @@ import type {
   DonationsDocumentWithoutDonorIds,
 } from "@/lib/api/donations-document";
 import type {
-  Country,
-  CountryCode,
   CountryConfig,
   UnloadedCountryConfig,
-} from "@/utils/countries";
+} from "@/types/country-config";
+import type { Country, CountryCode } from "@/utils/countries";
 import type { Donation, Party } from "@/utils/types";
 
 import { donationDocumentToDonations } from "@/lib/api/donations-document";
@@ -61,10 +60,7 @@ export const useCountryConfig = (country: Country) => {
   });
 };
 
-export const useDonationsByParty = (
-  country: UnloadedCountryConfig,
-  party: Party,
-) => {
+export const useDonationsByParty = (country: CountryConfig, party: Party) => {
   const build = getBuild(country.id).t;
 
   return useQuery<Donation[]>({
@@ -76,15 +72,19 @@ export const useDonationsByParty = (
   });
 };
 
-export const useNormalized = (country: UnloadedCountryConfig) => {
+export interface UseNormalizedData {
+  donorFilters?: UnloadedCountryConfig["donorFilters"];
+  receiverFilters?: UnloadedCountryConfig["receiverFilters"];
+  filteredDonors: string[];
+  filteredReceivers: string[];
+  normalizedDonors: [string, string[]][];
+  normalizedReceivers: [string, string[]][];
+}
+
+export const useNormalized = (country: CountryConfig) => {
   const build = getBuild(country.id).t;
 
-  return useQuery<{
-    filteredDonors: string[];
-    filteredReceivers: string[];
-    normalizedDonors: [string, string[]][];
-    normalizedReceivers: [string, string[]][];
-  }>({
+  return useQuery<UseNormalizedData>({
     queryKey: [country.id, "normalized"],
     queryFn: () =>
       jsonFetcher(
@@ -93,7 +93,7 @@ export const useNormalized = (country: UnloadedCountryConfig) => {
   });
 };
 
-export const useDonorNames = (country: UnloadedCountryConfig) => {
+export const useDonorNames = (country: CountryConfig) => {
   const build = getBuild(country.id).t;
 
   return useQuery({
@@ -111,7 +111,7 @@ export const useDonorNames = (country: UnloadedCountryConfig) => {
 };
 
 export const useDonationsByDonorId = (
-  country: UnloadedCountryConfig,
+  country: CountryConfig,
   donorId: string,
 ) => {
   const build = getBuild(country.id).t;
@@ -147,7 +147,7 @@ export const useDonationsByDonorId = (
 };
 
 export const useWikipediaByPageId = (
-  country: UnloadedCountryConfig,
+  country: CountryConfig,
   pageId: number,
 ) => {
   const build = getBuild(country.id).t;

--- a/src/types/country-config.ts
+++ b/src/types/country-config.ts
@@ -1,0 +1,68 @@
+import type { NonEmptyArray } from "@/utils/array";
+import type { Country, CountryCode, Currency } from "@/utils/countries";
+import type { LambertConformalConicParams } from "@/utils/map";
+import type {
+  DonorFilter,
+  IsoDate,
+  Party,
+  ReceiverFilter,
+} from "@/utils/types";
+
+// This is the raw country config containing everything relevant to the country.
+// This will get stripped down before being available to the next app.
+export interface UnloadedCountryConfig {
+  readonly id: Country;
+  readonly legislativeYears?: NonEmptyArray<NonEmptyArray<string>>;
+
+  // minimum year from which the data isn't complete yet
+  readonly preliminaryDataSince?: string;
+  readonly minPublicDonationAmount: number;
+  readonly source: { name: string; url: string };
+  readonly currency: Currency;
+  readonly code: CountryCode;
+
+  // Minimum year that this country has data for.
+  // Is used to e.g. skip scraping for years that are not available for a country
+  readonly minYear: string;
+
+  // markers in timeseries charts
+  readonly markers: {
+    label: string;
+    dates: IsoDate[];
+  };
+
+  // list of iso state codes
+  readonly states: readonly string[];
+
+  // Which wiki language should be used when linking/load a wiki article
+  readonly wikiCountry: "en" | "de";
+
+  // features that the country has, used to determine which information can be shown
+  readonly features: number;
+
+  // Include parties if they have count over this threshold or sum over the threshold.
+  // Use -1 if it should only check the other condition
+  readonly knownPartyRequirements?: {
+    count: number;
+    sum: number;
+  };
+
+  // Lambert Conformal Conic projection parameters for the country
+  readonly projection?: LambertConformalConicParams;
+
+  // filter out donations by donor
+  readonly donorFilters?: DonorFilter[];
+
+  // filtered out donation receivers
+  readonly receiverFilters?: ReceiverFilter[];
+}
+
+// This is the config type that's available to the next app
+export type CountryConfig = Omit<
+  UnloadedCountryConfig,
+  "donorFilters" | "receiverFilters"
+> & {
+  readonly years: string[];
+  // This is sorted by sum. Meaning first entry is the party with the highest sum of donations.
+  readonly parties: Party[];
+};

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,6 +1,8 @@
+import type { CountryConfig } from "@/types/country-config";
+
 import type { DonorType, ReceiverId } from "./types";
 
-import { type CountryConfig, getParty } from "./countries";
+import { getParty } from "./countries";
 
 export const partyColor = (partyId: ReceiverId, country: CountryConfig) => {
   return getParty(country, partyId).color;

--- a/src/utils/countries.ts
+++ b/src/utils/countries.ts
@@ -1,17 +1,13 @@
-import type { NonEmptyArray } from "@/utils/array";
+import type {
+  CountryConfig,
+  UnloadedCountryConfig,
+} from "@/types/country-config";
 import type { StrictNamespacedTranslator } from "@/utils/translator";
 
 import { Features } from "@/utils/features";
 
 import type En from "../messages/en.json";
-import type { LambertConformalConicParams } from "./map";
-import type {
-  DonorFilter,
-  IsoDate,
-  Party,
-  ReceiverFilter,
-  ReceiverId,
-} from "./types";
+import type { Party, ReceiverId } from "./types";
 
 export const enum Country {
   germany = "germany",
@@ -88,58 +84,8 @@ export const COUNTRIES = new Set<Country>([
   Country.sweden,
 ]);
 
-export interface CountryConfig {
-  readonly id: Country;
-  readonly years: string[];
-  // This is sorted by sum. Meaning first entry is the party with the highest sum of donations.
-  readonly parties: Party[];
-  readonly legislativeYears?: NonEmptyArray<NonEmptyArray<string>>;
-
-  // minimum year from which the data isn't complete yet
-  readonly preliminaryDataSince?: string;
-  readonly minPublicDonationAmount: number;
-  readonly source: { name: string; url: string };
-  readonly currency: Currency;
-  readonly code: CountryCode;
-
-  // Minimum year that this country has data for.
-  // Is used to e.g. skip scraping for years that are not available for a country
-  readonly minYear: string;
-
-  // markers in timeseries charts
-  readonly markers: {
-    label: string;
-    dates: IsoDate[];
-  };
-
-  // list of iso state codes
-  readonly states: readonly string[];
-
-  // Which wiki language should be used when linking/load a wiki article
-  readonly wikiCountry: "en" | "de";
-
-  // features that the country has, used to determine which information can be shown
-  readonly features: number;
-
-  // Include parties if they have count over this threshold or sum over the threshold.
-  // Use -1 if it should only check the other condition
-  readonly knownPartyRequirements?: {
-    count: number;
-    sum: number;
-  };
-
-  // Lambert Conformal Conic projection parameters for the country
-  readonly projection?: LambertConformalConicParams;
-
-  // filter out donations by donor
-  readonly donorFilters?: DonorFilter[];
-
-  // filtered out donation receivers
-  readonly receiverFilters?: ReceiverFilter[];
-}
-
-export type UnloadedCountryConfig = Omit<CountryConfig, "years" | "parties">;
-
+// This is the static config of each country.
+// During build in the data-loader it'll be joined with years and parties to be usable in the next app.
 export const COUNTRY_CONFIG: Record<Country, UnloadedCountryConfig> = {
   [Country.germany]: {
     id: Country.germany,

--- a/src/utils/data/get-country-config.ts
+++ b/src/utils/data/get-country-config.ts
@@ -1,22 +1,8 @@
-import type { CountryConfig } from "../countries";
+import type { CountryConfig } from "@/types/country-config";
 
-import { Country, COUNTRY_CONFIG } from "../countries";
+import { Country } from "../countries";
 import { loadCountryData } from "../loader/country-data-loaders";
 
-const loaded: Record<string, CountryConfig> = {};
-export const getCountryConfig = async (
-  country: Country,
-): Promise<CountryConfig> => {
-  // return cached one
-  if (loaded[country]) return loaded[country];
-
-  const dataset = await loadCountryData(country, "yearParties");
-
-  const config = {
-    ...COUNTRY_CONFIG[country],
-    ...dataset,
-  };
-
-  loaded[country] = config;
-  return config;
+export const getCountryConfig = (country: Country): Promise<CountryConfig> => {
+  return loadCountryData(country, "countryConfig");
 };

--- a/src/utils/data/get-history.ts
+++ b/src/utils/data/get-history.ts
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "../countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { donationYear } from "../date";
 import { Donation, DonationField, ReceiverId } from "../types";

--- a/src/utils/data/get-origin-donations.ts
+++ b/src/utils/data/get-origin-donations.ts
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "../countries";
+import type { CountryConfig } from "@/types/country-config";
 
 import { donationYear } from "../date";
 import { numbersSum } from "../math";

--- a/src/utils/data/get-parties-sum.ts
+++ b/src/utils/data/get-parties-sum.ts
@@ -1,4 +1,5 @@
-import type { CountryConfig } from "../countries";
+import type { CountryConfig } from "@/types/country-config";
+
 import type { PartyStats, PartyYearsSums } from "../loader/party-years-sums";
 import type { Party, ReceiverId } from "../types";
 

--- a/src/utils/data/get-parties.ts
+++ b/src/utils/data/get-parties.ts
@@ -1,6 +1,6 @@
 import { getTranslations } from "next-intl/server";
 
-import type { CountryConfig } from "../countries";
+import type { CountryConfig } from "@/types/country-config";
 
 export const getParties = (country: CountryConfig, years: string[]) => {
   const yearsSet = new Set(years);

--- a/src/utils/election-marker.ts
+++ b/src/utils/election-marker.ts
@@ -1,6 +1,7 @@
 import type { MarkLineComponentOption } from "echarts";
 
-import type { CountryConfig } from "./countries";
+import type { CountryConfig } from "@/types/country-config";
+
 import type { IsoDate } from "./types";
 
 const electionIcon = (color: string) =>

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 
 export const enum Features {
   // default value, no special features supported

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,4 +1,6 @@
-import type { CountryConfig, Currency } from "./countries";
+import type { CountryConfig } from "@/types/country-config";
+
+import type { Currency } from "./countries";
 import type { ConstLocale } from "./locales";
 import type { ReceiverId } from "./types";
 

--- a/src/utils/loader/country-data-loaders.ts
+++ b/src/utils/loader/country-data-loaders.ts
@@ -1,6 +1,8 @@
+import type { CountryConfig } from "@/types/country-config";
+
 import type { Country } from "../countries";
 import type { HistoryEntry } from "../data/get-history";
-import type { Donation, Party } from "../types";
+import type { Donation } from "../types";
 import type { BigDonor } from "./biggest-donors";
 import type { PartyYearsSums } from "./party-years-sums";
 
@@ -10,12 +12,7 @@ interface CountryLoaders {
   partySums: (country: Country) => Promise<DefaultExport<PartyYearsSums>>;
   mostRecent: (country: Country) => Promise<DefaultExport<HistoryEntry[]>>;
   biggestDonors: (country: Country) => Promise<DefaultExport<BigDonor[]>>;
-  yearParties: (country: Country) => Promise<
-    DefaultExport<{
-      years: string[];
-      parties: Party[];
-    }>
-  >;
+  countryConfig: (country: Country) => Promise<DefaultExport<CountryConfig>>;
   biggestDonations: (country: Country) => Promise<DefaultExport<Donation[]>>;
 }
 
@@ -25,7 +22,8 @@ const loaders: CountryLoaders = {
   mostRecent: (country: Country) => import(`../../data/${country}/most-recent`),
   biggestDonors: (country: Country) =>
     import(`../../data/${country}/biggest-donors`),
-  yearParties: (country: Country) => import(`../../data/${country}/config`),
+  countryConfig: (country: Country) =>
+    import(`../../data/${country}/country-config`),
   biggestDonations: (country: Country) =>
     import(`../../data/${country}/biggest-donations`),
 };

--- a/src/utils/loader/party-years-sums.ts
+++ b/src/utils/loader/party-years-sums.ts
@@ -1,4 +1,6 @@
-import type { Country, CountryConfig } from "../countries";
+import type { CountryConfig } from "@/types/country-config";
+
+import type { Country } from "../countries";
 import type { ReceiverId } from "../types";
 
 import { getBuild } from "./build";

--- a/src/utils/party.ts
+++ b/src/utils/party.ts
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 
 import { Features, hasFeature } from "@/utils/features";

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "./countries";
+import type { CountryConfig } from "@/types/country-config";
 
 const YEAR_DELIMITER = "-";
 

--- a/src/utils/title.ts
+++ b/src/utils/title.ts
@@ -1,6 +1,7 @@
+import type { CountryConfig } from "@/types/country-config";
 import type { StrictNamespacedTranslator } from "@/utils/translator";
 
-import { type CountryConfig, getCountryName } from "./countries";
+import { getCountryName } from "./countries";
 
 export const generateCountryTitlePart = (
   country: CountryConfig,

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,4 +1,6 @@
-import type { Country, CountryConfig } from "./countries";
+import type { CountryConfig } from "@/types/country-config";
+
+import type { Country } from "./countries";
 import type { ConstLocale } from "./locales";
 import type { ReceiverId } from "./types";
 

--- a/tasks/fake-data/generate-fake-data.ts
+++ b/tasks/fake-data/generate-fake-data.ts
@@ -1,10 +1,7 @@
 import debug from "debug";
 
-import type {
-  Country,
-  CountryCode,
-  UnloadedCountryConfig,
-} from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Country, CountryCode } from "@/utils/countries";
 import type {
   DonorMetaDefinition,
   ExtractedDonationAddress,
@@ -184,7 +181,7 @@ const useCountries = await promptCountries(
 );
 
 const generateFakeWikipediaArticles = async (
-  countryConfig: UnloadedCountryConfig,
+  countryConfig: Pick<CountryConfig, "id" | "code" | "minYear">,
   donorMeta: DonorMetaDefinition,
 ) => {
   const fakeText = "This is a fake Wikipedia article for testing purposes.";

--- a/tasks/load-data/data-loader.ts
+++ b/tasks/load-data/data-loader.ts
@@ -4,12 +4,15 @@ import fs, { constants } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 
+import type {
+  CountryConfig,
+  UnloadedCountryConfig,
+} from "@/types/country-config";
 import type { Country, CountryCode } from "@/utils/countries";
 import type {
   Donation,
   DonorMetaDefinition,
   ExtractedDonationAddress,
-  Party,
   ReceiverId,
 } from "@/utils/types";
 
@@ -53,11 +56,10 @@ export type ExtractedYearData = Omit<
  */
 interface ProcessedDonationData {
   donations: Donation[];
-  donationData: {
-    years: string[];
-    parties: Party[];
-  };
+  countryConfig: CountryConfig;
   transparencyData: {
+    donorFilters?: UnloadedCountryConfig["donorFilters"];
+    receiverFilters?: UnloadedCountryConfig["receiverFilters"];
     filteredDonors: string[];
     filteredReceivers: string[];
     normalizedDonors: [string, string[]][];
@@ -119,7 +121,7 @@ export abstract class DataLoader {
   private readonly donationsDataPath: string;
   private readonly transparencyDataPath: string;
   private readonly donorMetaPath: string;
-  private readonly configPath: string;
+  private readonly countryConfigPath: string;
   private readonly buildMetaPath: string;
   protected readonly anonymizedDonorsPath: string;
 
@@ -146,7 +148,7 @@ export abstract class DataLoader {
     this.donorMetaPath = path.join(this.taskDataDir, "donor-meta.ts");
     this.transparencyDataPath = path.join(this.taskDataDir, "transparency.ts");
 
-    this.configPath = path.join(this.dataDir, "config.ts");
+    this.countryConfigPath = path.join(this.dataDir, "country-config.ts");
     this.buildMetaPath = path.join(this.dataDir, "build.ts");
 
     this.anonymizedDonorsPath = path.join(
@@ -286,7 +288,7 @@ export abstract class DataLoader {
   public processYearData(
     extractedData: ExtractedYearData[],
   ): ProcessedDonationData {
-    const countryConfig = COUNTRY_CONFIG[this.country];
+    const rawUnloadedCountryConfig = COUNTRY_CONFIG[this.country];
     const parties = new Set<string>([]);
     const partySums: Record<string, number> = {};
     const partyYears: Record<string, Set<string>> = {};
@@ -301,7 +303,7 @@ export abstract class DataLoader {
         // Uses absolute value to also filter out negative donations below the threshold
         if (
           Math.abs(d[DonationField.Amount]) <
-          countryConfig.minPublicDonationAmount
+          rawUnloadedCountryConfig.minPublicDonationAmount
         ) {
           return false;
         }
@@ -312,12 +314,12 @@ export abstract class DataLoader {
 
     const filteredOutDonors = new Set<string>();
     const filteredOutReceivers = new Set<string>();
-    const donorFilters = (countryConfig.donorFilters ?? []).map(
+    const donorFiltersRegex = (rawUnloadedCountryConfig.donorFilters ?? []).map(
       (filter) => new RegExp(filter, "i"),
     );
-    const receiverFilters = (countryConfig.receiverFilters ?? []).map(
-      (filter) => new RegExp(filter, "i"),
-    );
+    const receiverFilterRegex = (
+      rawUnloadedCountryConfig.receiverFilters ?? []
+    ).map((filter) => new RegExp(filter, "i"));
 
     const normalizedReceivers: Record<string, Set<string>> = {};
 
@@ -372,7 +374,7 @@ export abstract class DataLoader {
           const receiver = d[DonationField.Receiver];
 
           // filter if ignored receiver
-          if (!applyDonorReceiverFilters(receiver, receiverFilters)) {
+          if (!applyDonorReceiverFilters(receiver, receiverFilterRegex)) {
             filteredOutReceivers.add(receiver);
             return false;
           }
@@ -402,7 +404,7 @@ export abstract class DataLoader {
       );
 
       // filter if ignored donor
-      if (!applyDonorReceiverFilters(donorName, donorFilters)) {
+      if (!applyDonorReceiverFilters(donorName, donorFiltersRegex)) {
         filteredOutDonors.add(donorName);
         return;
       }
@@ -531,10 +533,19 @@ export abstract class DataLoader {
 
     assertNoDuplicateIds(donations);
 
+    const { donorFilters, receiverFilters, ...countryConfig } =
+      rawUnloadedCountryConfig;
+
     return {
       donations,
-      donationData,
+      countryConfig: {
+        ...countryConfig,
+        years: donationData.years,
+        parties: donationData.parties,
+      },
       transparencyData: {
+        donorFilters,
+        receiverFilters,
         filteredDonors: [...filteredOutDonors].toSorted(([a], [b]) =>
           b.localeCompare(a),
         ),
@@ -588,17 +599,12 @@ export abstract class DataLoader {
         }),
       ),
       writeIfChanged(
-        this.configPath,
-        jsonAsTsModuleWithType(JSON.stringify(processedData.donationData), {
-          name: `{
-    years: string[];
-    parties: Party[];
-  }`,
-          as: `{
-    years: string[];
-    parties: Party[];
-  }`,
-          import: 'import type { Party } from "../../../src/utils/types";',
+        this.countryConfigPath,
+        jsonAsTsModuleWithType(JSON.stringify(processedData.countryConfig), {
+          name: `CountryConfig`,
+          as: `CountryConfig`,
+          import:
+            'import type { CountryConfig } from "@/types/country-config";',
         }),
       ),
     ]);

--- a/tasks/load-data/postprocess.ts
+++ b/tasks/load-data/postprocess.ts
@@ -3,7 +3,8 @@ import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 
-import type { CountryCode, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { CountryCode } from "@/utils/countries";
 import type {
   PartyStats,
   PartyYearsSums,

--- a/tasks/social-images/components/donor-header.tsx
+++ b/tasks/social-images/components/donor-header.tsx
@@ -3,6 +3,7 @@
 
 import type { PropsWithChildren, ReactNode } from "react";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { PartySum } from "@/utils/data/get-parties-sum";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
 import type { ConstLocale } from "@/utils/locales";
@@ -10,11 +11,7 @@ import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import { PageLogo } from "@/components/layout/page-logo";
 import { partyColor } from "@/utils/color";
-import {
-  type CountryConfig,
-  getCountryName,
-  getParty,
-} from "@/utils/countries";
+import { getCountryName, getParty } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
 import { getDonorName } from "@/utils/donor";
 import {

--- a/tasks/social-images/components/image-footer.tsx
+++ b/tasks/social-images/components/image-footer.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable react/no-unknown-property */
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 
 import { isNotNullandNotUndefined } from "@/utils/array";

--- a/tasks/social-images/components/image-party-header.tsx
+++ b/tasks/social-images/components/image-party-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { Donation, Party } from "@/utils/types";
 

--- a/tasks/social-images/components/image-years-header.tsx
+++ b/tasks/social-images/components/image-years-header.tsx
@@ -4,17 +4,14 @@
 
 import type { PropsWithChildren, ReactNode } from "react";
 
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 import type { Donation, Party, ReceiverId } from "@/utils/types";
 
 import { PageLogo } from "@/components/layout/page-logo";
 import { partyColor } from "@/utils/color";
-import {
-  type CountryConfig,
-  getCountryName,
-  getParty,
-} from "@/utils/countries";
+import { getCountryName, getParty } from "@/utils/countries";
 import { getParties } from "@/utils/data/get-parties";
 import { getPartiesSum } from "@/utils/data/get-parties-sum";
 import { donationYear } from "@/utils/date";

--- a/tasks/social-images/generate-images.test.tsx
+++ b/tasks/social-images/generate-images.test.tsx
@@ -9,7 +9,7 @@ import satori from "satori";
 import { fileURLToPath } from "url";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { Donation } from "@/utils/types";

--- a/tasks/social-images/images/country-page-image.tsx
+++ b/tasks/social-images/images/country-page-image.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable react/no-unknown-property */
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 

--- a/tasks/social-images/images/country-years-page-image.tsx
+++ b/tasks/social-images/images/country-years-page-image.tsx
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 import type { Donation } from "@/utils/types";

--- a/tasks/social-images/images/donor-image.tsx
+++ b/tasks/social-images/images/donor-image.tsx
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
 import type { ConstLocale } from "@/utils/locales";
 import type { Donation } from "@/utils/types";

--- a/tasks/social-images/images/party-page-image.tsx
+++ b/tasks/social-images/images/party-page-image.tsx
@@ -1,4 +1,4 @@
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { Donation, ReceiverId } from "@/utils/types";
 

--- a/tasks/social-images/images/root-page-image.tsx
+++ b/tasks/social-images/images/root-page-image.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { Country, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Country } from "@/utils/countries";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 

--- a/tasks/social-media/generate-social-media-posts.ts
+++ b/tasks/social-media/generate-social-media-posts.ts
@@ -9,7 +9,7 @@ import {
 } from "typescript";
 import { promisify } from "util";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 import type { StrictNamespacedTranslator } from "@/utils/translator";
 import type { Donation, ReceiverId } from "@/utils/types";
@@ -53,6 +53,7 @@ const countryTranslations: Record<Country, ConstLocale> = {
   [Country.norway]: "no",
   [Country.ukraine]: "uk",
   [Country.france]: "fr",
+  [Country.sweden]: "en",
 };
 
 const countryFlags: Record<Country, string> = {
@@ -73,6 +74,7 @@ const countryFlags: Record<Country, string> = {
   [Country.norway]: "🇳🇴",
   [Country.ukraine]: "🇺🇦",
   [Country.france]: "🇫🇷",
+  [Country.sweden]: "🇸🇪",
 };
 
 const deltaPrefix = (delta: number): string => (delta > 0 ? `+` : "");

--- a/tasks/wikipedia/populate-wikipedia-articles.ts
+++ b/tasks/wikipedia/populate-wikipedia-articles.ts
@@ -1,4 +1,5 @@
-import type { Country, CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
+import type { Country } from "@/utils/countries";
 import type { Donation, DonorMetaDefinition } from "@/utils/types";
 
 import { getCountryConfig } from "@/utils/data/get-country-config";

--- a/tests/data-integrity.test.ts
+++ b/tests/data-integrity.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from "vitest";
 
-import type { CountryConfig } from "@/utils/countries";
+import type { CountryConfig } from "@/types/country-config";
 import type { Donation } from "@/utils/types";
 
 import { COUNTRIES } from "@/utils/countries";

--- a/tests/data-loader/data-loader.test.ts
+++ b/tests/data-loader/data-loader.test.ts
@@ -211,11 +211,11 @@ describe("data loader", () => {
 
     const result = loader.processYearData(donations);
 
-    expect(result.donationData.parties).toHaveLength(2);
-    expect(result.donationData.parties[0].id).toBe("BETA");
-    expect(result.donationData.parties[0].sum).toBe(200_000);
-    expect(result.donationData.parties[1].id).toBe("ALPHA");
-    expect(result.donationData.parties[1].sum).toBe(100_000);
+    expect(result.countryConfig.parties).toHaveLength(2);
+    expect(result.countryConfig.parties[0].id).toBe("BETA");
+    expect(result.countryConfig.parties[0].sum).toBe(200_000);
+    expect(result.countryConfig.parties[1].id).toBe("ALPHA");
+    expect(result.countryConfig.parties[1].sum).toBe(100_000);
   });
 
   test("processYearData assigns unique ids per donation", () => {


### PR DESCRIPTION
## Description

Extracts rarely used data from country config to avoid serializing it all over the place.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Data update/addition
- [ ] Documentation update
- [x] Refactoring

## Testing

- [x] Unit tests pass (`pnpm test:unit`)
- [x] Lint passes (`pnpm lint`)
- [x] E2E tests pass (`pnpm test:e2e`) - if UI changes
