### PR TITLE
fix: use navigator locale in formatters if it matches selected language

### DIFF
--- a/e2e/donor.spec.ts
+++ b/e2e/donor.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from "@playwright/test";
 
+import type { BrowserBasedLocale } from "@/utils/locales";
+
+import { makeBrand } from "@/utils/brand";
 import { formatAnd } from "@/utils/formatter";
 
 import { hash } from "../tasks/load-data/util";
@@ -57,7 +60,11 @@ test.describe("Donor page", () => {
     await page.goto(`${baseURL}/germany/donor/${hash(DONOR_WITH_UBOs)}`);
 
     await expect(donorPage.uboText).toHaveText(
-      formatAnd(locale, ["Fake UBO 1", "Fake UBO 2"]),
+      // Branded as BrowserBasedLocale to satisfy formatter types in tests.
+      formatAnd(makeBrand<BrowserBasedLocale>(locale), [
+        "Fake UBO 1",
+        "Fake UBO 2",
+      ]),
     );
 
     await test.step("is accessible", async () => {

--- a/e2e/party-page.spec.ts
+++ b/e2e/party-page.spec.ts
@@ -106,6 +106,33 @@ test.describe("Party page", () => {
         ).toHaveCount(0);
       });
     });
+
+    test("shows date based on the navigator language", async ({
+      page,
+      baseURL,
+      historyPage,
+      browser,
+    }) => {
+      await page.goto(`${baseURL}/germany/party/${CHECK_PARTY}/changes`);
+      const dateCell = historyPage.tableRows.first().locator("td").nth(0);
+
+      await test.step("en useragent uses en-US format", async () => {
+        await expect(dateCell).toHaveText("12/26/26");
+      });
+
+      await test.step("en-GB useragent uses en-GB format", async () => {
+        const context = await browser.newContext({ locale: "en-GB" });
+        const gbPage = await context.newPage();
+        await gbPage.goto(`${baseURL}/germany/party/${CHECK_PARTY}/changes`);
+        const gbDateCell = gbPage
+          .locator("table tbody tr")
+          .first()
+          .locator("td")
+          .nth(0);
+        await expect(gbDateCell).toHaveText("26/12/26");
+        await context.close();
+      });
+    });
   });
 
   test.describe("timeline page", () => {

--- a/src/app/[locale]/[country]/[years]/changes/page.tsx
+++ b/src/app/[locale]/[country]/[years]/changes/page.tsx
@@ -17,7 +17,11 @@ import {
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
 import { deserializeYears } from "@/utils/serializers";
-import { isValidCountry, isValidLocale } from "@/utils/validate";
+import {
+  isValidCountry,
+  isValidLocale,
+  isValidMetadataLocale,
+} from "@/utils/validate";
 
 import { YearsChangesClientPage } from "./_components/years-changes-client-page";
 
@@ -26,7 +30,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const params = await props.params;
 
-  if (!isValidLocale(params.locale)) return notFoundMetadata;
+  if (!isValidMetadataLocale(params.locale)) return notFoundMetadata;
   if (!isValidCountry(params.country)) return notFoundMetadata;
 
   setRequestLocale(params.locale);

--- a/src/app/[locale]/[country]/[years]/overview/_components/years-overview-client-page.tsx
+++ b/src/app/[locale]/[country]/[years]/overview/_components/years-overview-client-page.tsx
@@ -23,6 +23,7 @@ import { TextPartyLink } from "@/components/parties/text-party-link";
 import { Translation } from "@/components/translation";
 import { LoadedTopPartyDonations } from "@/components/years/top-party-year-donations";
 import { useDonationsByYears } from "@/hooks/use-api";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { useScrollToHash } from "@/hooks/use-scroll-to-hash";
 import { isNotNullandNotUndefined } from "@/utils/array";
@@ -59,6 +60,7 @@ export const YearsOverviewClientPage = ({
   const t = useTranslations();
   const tData = useTranslations("data");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const results = useDonationsByYears(country, years);
   const isLoading = results.some((r) => r.isLoading);
   const error = results.some((r) => r.error);
@@ -102,15 +104,19 @@ export const YearsOverviewClientPage = ({
             <p className="mb-6">{summary}</p>
             <p className="mb-6">
               {t("overview.detail.summary2", {
-                years: formatAnd(locale, years),
+                years: formatAnd(browserBasedLocale, years),
                 partyCount: sums.length,
                 donationCount: count,
                 minimumAmount: formatCompactCountryCurrency(
-                  locale,
+                  browserBasedLocale,
                   country.minPublicDonationAmount,
                   country,
                 ),
-                donationSum: formatCountryCurrency(locale, sum, country),
+                donationSum: formatCountryCurrency(
+                  browserBasedLocale,
+                  sum,
+                  country,
+                ),
               })}
             </p>
             {topDonationSums.length ? (
@@ -118,7 +124,7 @@ export const YearsOverviewClientPage = ({
                 <Translation
                   text={t.raw("overview.detail.highest_sum")}
                   variables={{
-                    years: formatAnd(locale, years),
+                    years: formatAnd(browserBasedLocale, years),
                     parties: (
                       <FormatAnd
                         locale={locale}
@@ -129,7 +135,13 @@ export const YearsOverviewClientPage = ({
                               party={receiverId}
                               locale={locale}
                             />
-                            ({formatCountryCurrency(locale, sum.sum, country)})
+                            (
+                            {formatCountryCurrency(
+                              browserBasedLocale,
+                              sum.sum,
+                              country,
+                            )}
+                            )
                           </span>
                         ))}
                       />
@@ -152,7 +164,7 @@ export const YearsOverviewClientPage = ({
                     ),
                     count: mostDonations[1].count,
                     sum: formatCountryCurrency(
-                      locale,
+                      browserBasedLocale,
                       mostDonations[1].sum,
                       country,
                     ),

--- a/src/app/[locale]/[country]/[years]/overview/page.tsx
+++ b/src/app/[locale]/[country]/[years]/overview/page.tsx
@@ -23,7 +23,11 @@ import {
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
 import { deserializeYears } from "@/utils/serializers";
-import { isValidCountry, isValidLocale } from "@/utils/validate";
+import {
+  isValidCountry,
+  isValidLocale,
+  isValidMetadataLocale,
+} from "@/utils/validate";
 
 import { YearsOverviewClientPage } from "./_components/years-overview-client-page";
 
@@ -32,7 +36,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const params = await props.params;
 
-  if (!isValidLocale(params.locale)) return notFoundMetadata;
+  if (!isValidMetadataLocale(params.locale)) return notFoundMetadata;
   if (!isValidCountry(params.country)) return notFoundMetadata;
   setRequestLocale(params.locale);
 

--- a/src/app/[locale]/[country]/donor/[donorId]/_components/donor-client-page-content.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/_components/donor-client-page-content.tsx
@@ -16,6 +16,7 @@ import {
 import { TextPartyLink } from "@/components/parties/text-party-link";
 import { PercentageHint } from "@/components/percentage-hint";
 import { Translation } from "@/components/translation";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import { getCountryName, getParty } from "@/utils/countries";
@@ -41,6 +42,7 @@ export const DonorClientPageContent = ({
   const tCountries = useTranslations("countries");
   const tCommon = useTranslations("common");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const donorName = getDonorName(
     donations.at(0)?.[DonationField.DonorName] ?? "",
     tCommon,
@@ -136,11 +138,19 @@ export const DonorClientPageContent = ({
           <p className="mb-6">
             {tDonor("summary", {
               donor: donorName,
-              sum: formatCountryCurrency(locale, sum, countryConfig),
-              count: formatNumber(locale, donations.length),
-              avg: formatCountryCurrency(locale, avg, countryConfig),
+              sum: formatCountryCurrency(
+                browserBasedLocale,
+                sum,
+                countryConfig,
+              ),
+              count: formatNumber(browserBasedLocale, donations.length),
+              avg: formatCountryCurrency(
+                browserBasedLocale,
+                avg,
+                countryConfig,
+              ),
               parties: formatNumber(
-                locale,
+                browserBasedLocale,
                 Object.keys(donationParties).length,
               ),
             })}
@@ -165,13 +175,13 @@ export const DonorClientPageContent = ({
                   <div className="ml-2 flex tabular-nums">
                     <span className="lg:mr-1">
                       {formatCountryCurrency(
-                        locale,
+                        browserBasedLocale,
                         partyDonation.sum,
                         countryConfig,
                       )}
                     </span>
                     <PercentageHint
-                      locale={locale}
+                      browserBasedLocale={browserBasedLocale}
                       percentage={partyDonation.sum / sum}
                     />
                   </div>
@@ -186,11 +196,11 @@ export const DonorClientPageContent = ({
                   variables={{
                     minYear: countryConfig.minYear,
                     date: formatDate(
-                      locale,
+                      browserBasedLocale,
                       new Date(oldestDonation[DonationField.Date]),
                     ),
                     amount: formatCountryCurrency(
-                      locale,
+                      browserBasedLocale,
                       oldestDonation[DonationField.Amount],
                       countryConfig,
                     ),
@@ -214,11 +224,11 @@ export const DonorClientPageContent = ({
                   text={tDonor.raw("newest")}
                   variables={{
                     date: formatDate(
-                      locale,
+                      browserBasedLocale,
                       new Date(newestDonation[DonationField.Date]),
                     ),
                     amount: formatCountryCurrency(
-                      locale,
+                      browserBasedLocale,
                       newestDonation[DonationField.Amount],
                       countryConfig,
                     ),
@@ -240,11 +250,11 @@ export const DonorClientPageContent = ({
               text={tDonor.raw("most_donations")}
               variables={{
                 list: formatAnd(
-                  locale,
+                  browserBasedLocale,
                   mostPartyDonations.map(({ party, count }) =>
                     tDonor("most_donations_item", {
                       party: getParty(countryConfig, party)[PartyField.Short],
-                      count: formatNumber(locale, count),
+                      count: formatNumber(browserBasedLocale, count),
                     }),
                   ),
                 ),
@@ -256,12 +266,15 @@ export const DonorClientPageContent = ({
                 {tDonor("highest_most_donation", {
                   biggestYear: biggestYear.year,
                   biggestSum: formatCountryCurrency(
-                    locale,
+                    browserBasedLocale,
                     biggestYear.sum,
                     countryConfig,
                   ),
                   mostYear: mostDonationsYear.year,
-                  mostCount: formatNumber(locale, mostDonationsYear.count),
+                  mostCount: formatNumber(
+                    browserBasedLocale,
+                    mostDonationsYear.count,
+                  ),
                 })}
               </>
             ) : null}
@@ -272,12 +285,12 @@ export const DonorClientPageContent = ({
                   text={tDonor.raw("biggest")}
                   variables={{
                     amount: formatCountryCurrency(
-                      locale,
+                      browserBasedLocale,
                       biggestDonation[DonationField.Amount],
                       countryConfig,
                     ),
                     date: formatDate(
-                      locale,
+                      browserBasedLocale,
                       new Date(biggestDonation[DonationField.Date]),
                     ),
                     party: (

--- a/src/app/[locale]/[country]/donor/[donorId]/_components/donor-donation-timeline.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/_components/donor-donation-timeline.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Donation, ReceiverId } from "@/utils/types";
 
@@ -12,6 +10,7 @@ import {
   ArticleSectionTwoColumns,
   ArticleSectionWrapper,
 } from "@/components/layout/article";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { getCountryName, getParty } from "@/utils/countries";
 import { donationYear, fillYears } from "@/utils/date";
@@ -30,7 +29,7 @@ export const DonorDonationTimeline = ({
   const tCountries = useTranslations("countries");
   const tDonor = useTranslations("donor");
   const tCommon = useTranslations("common");
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const firstYear = donationYear(donations[0]);
   const lastYear = donationYear(donations[donations.length - 1]);
   const donorName = getDonorName(
@@ -80,14 +79,18 @@ export const DonorDonationTimeline = ({
                   <span>{year}</span>
                   <span className="tabular-nums">
                     <span>
-                      {formatCountryCurrency(locale, yearSum, countryConfig)}
+                      {formatCountryCurrency(
+                        browserBasedLocale,
+                        yearSum,
+                        countryConfig,
+                      )}
                     </span>{" "}
                     <span
                       className={
                         "hidden w-14 text-right text-gray-500 lg:inline-block dark:text-gray-400"
                       }
                     >
-                      ({formatPercentFormat(locale, yearSum / sum)})
+                      ({formatPercentFormat(browserBasedLocale, yearSum / sum)})
                     </span>
                   </span>
                 </div>

--- a/src/app/[locale]/[country]/donor/[donorId]/_components/donor-donation-types-sankey.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/_components/donor-donation-types-sankey.tsx
@@ -3,12 +3,11 @@
 import type { EChartsOption } from "echarts";
 import type { SankeyNodeItemOption } from "echarts/types/src/chart/sankey/SankeySeries.js";
 
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { ExpandableReactEchart } from "@/components/charts/expandable-react-echart";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -35,7 +34,7 @@ export const DonorDonationTypesSankey = ({
   donations: Donation[];
   donorName: string;
 }) => {
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { backgroundColor, isDark } = useChart();
   const tDonationType = useTranslations("donation_type");
   const tDonor = useTranslations("donor");
@@ -84,7 +83,7 @@ export const DonorDonationTypesSankey = ({
         color: "#4338ca",
       },
       label: {
-        formatter: `${truncate(donorName, 22)}\n${formatCompactCountryCurrency(locale, totalSum, countryConfig)}`,
+        formatter: `${truncate(donorName, 22)}\n${formatCompactCountryCurrency(browserBasedLocale, totalSum, countryConfig)}`,
       },
     },
   ];
@@ -102,7 +101,7 @@ export const DonorDonationTypesSankey = ({
       name: partyShortName,
       itemStyle: { color: partyColor(receiver, countryConfig) },
       label: {
-        formatter: `${truncate(partyShortName, 22)}\n${formatCompactCountryCurrency(locale, partySum[receiver]!, countryConfig)}`,
+        formatter: `${truncate(partyShortName, 22)}\n${formatCompactCountryCurrency(browserBasedLocale, partySum[receiver]!, countryConfig)}`,
       },
     });
 
@@ -121,7 +120,7 @@ export const DonorDonationTypesSankey = ({
         name: `${capitalizedType} (${partyShortName})`,
         itemStyle: { color: chartColorFor(type) },
         label: {
-          formatter: `${truncate(capitalizedType, 22)}\n${formatCompactCountryCurrency(locale, amount!, countryConfig)}`,
+          formatter: `${truncate(capitalizedType, 22)}\n${formatCompactCountryCurrency(browserBasedLocale, amount!, countryConfig)}`,
         },
       });
     }
@@ -159,7 +158,7 @@ export const DonorDonationTypesSankey = ({
       formatter: (params) => {
         if (Array.isArray(params)) return "";
         const value = formatCountryCurrency(
-          locale,
+          browserBasedLocale,
           params.value as number,
           countryConfig,
         );

--- a/src/app/[locale]/[country]/donor/[donorId]/_components/donor-donation-types.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/_components/donor-donation-types.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/layout/article";
 import { TextPartyLink } from "@/components/parties/text-party-link";
 import { Translation } from "@/components/translation";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { getDonorName } from "@/utils/donor";
 import { formatCountryCurrency, formatPercentFormat } from "@/utils/formatter";
@@ -33,6 +34,7 @@ export const DonorDonationTypes = ({
   const tDonor = useTranslations("donor");
   const tDonationType = useTranslations("donation_type");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const donorName = getDonorName(
     donations.at(0)?.[DonationField.DonorName] ?? "",
     tCommon,
@@ -86,7 +88,7 @@ export const DonorDonationTypes = ({
                       .map((type) =>
                         tDonor("donation_type.summary_item", {
                           amount: formatCountryCurrency(
-                            locale,
+                            browserBasedLocale,
                             typeSum[type] ?? 0,
                             countryConfig,
                           ),
@@ -109,9 +111,18 @@ export const DonorDonationTypes = ({
                     <div className="mb-1 flex items-center justify-between text-sm font-semibold">
                       <span>{capitalize(tDonationType(`${type}`))}</span>
                       <span className="tabular-nums">
-                        {formatCountryCurrency(locale, sum, countryConfig)}{" "}
+                        {formatCountryCurrency(
+                          browserBasedLocale,
+                          sum,
+                          countryConfig,
+                        )}{" "}
                         <span className="text-gray-500 dark:text-gray-400">
-                          ({formatPercentFormat(locale, sum / totalSum)})
+                          (
+                          {formatPercentFormat(
+                            browserBasedLocale,
+                            sum / totalSum,
+                          )}
+                          )
                         </span>
                       </span>
                     </div>
@@ -130,7 +141,7 @@ export const DonorDonationTypes = ({
                             />
                             <span className="tabular-nums">
                               {formatCountryCurrency(
-                                locale,
+                                browserBasedLocale,
                                 partySum,
                                 countryConfig,
                               )}

--- a/src/app/[locale]/[country]/donor/[donorId]/donor-page-head.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/donor-page-head.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { HatGlasses, Info, Lock } from "lucide-react";
-import { useLocale } from "next-intl";
 
 import type { CountryConfig } from "@/types/country-config";
 import type { Countries, Country } from "@/utils/countries";
@@ -19,6 +18,7 @@ import {
 } from "@/components/ui/tooltip";
 import { WikiQuote } from "@/components/wiki-quote";
 import { useDonationsByDonorId } from "@/hooks/use-api";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { partyColor } from "@/utils/color";
 import { donationYear } from "@/utils/date";
@@ -152,7 +152,7 @@ const DonorPageHeadContent = ({
 }) => {
   const t = useTranslations();
   const tCommon = useTranslations("common");
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const wikiPageId = donorMeta.wiki;
 
   const rawDonorName = donations.at(0)?.[DonationField.DonorName] ?? "";
@@ -257,16 +257,24 @@ const DonorPageHeadContent = ({
             <div className="flex-row space-y-2 sm:flex sm:space-y-0 sm:space-x-10">
               <MetaCard
                 title={t("donation_count")}
-                value={formatNumber(locale, donations.length)}
+                value={formatNumber(browserBasedLocale, donations.length)}
               />
               <MetaCard
                 title={t("sum")}
-                value={formatCountryCurrency(locale, sum, countryConfig)}
+                value={formatCountryCurrency(
+                  browserBasedLocale,
+                  sum,
+                  countryConfig,
+                )}
               />
               {donations.length > 1 ? (
                 <MetaCard
                   title={t("average")}
-                  value={formatCountryCurrency(locale, avg, countryConfig)}
+                  value={formatCountryCurrency(
+                    browserBasedLocale,
+                    avg,
+                    countryConfig,
+                  )}
                 />
               ) : null}
               <MetaCard
@@ -286,7 +294,6 @@ const DonorPageHeadContent = ({
                 <div className="mt-2 flex flex-wrap gap-2">
                   {donorMeta.relations.map(([name, kind, sums]) => (
                     <RelatedDonorChip
-                      locale={locale}
                       key={name}
                       name={name}
                       kind={kind}
@@ -308,7 +315,9 @@ const DonorPageHeadContent = ({
                     </>
                   }
                 />
-                <p className="mt-2">{formatAnd(locale, [...ubos])}</p>
+                <p className="mt-2">
+                  {formatAnd(browserBasedLocale, [...ubos])}
+                </p>
               </section>
             ) : null}
           </div>

--- a/src/app/[locale]/[country]/donor/[donorId]/page.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/page.tsx
@@ -20,7 +20,11 @@ import { getBiggestDonors } from "@/utils/loader/biggest-donors";
 import { baseOpenGraph, baseTwitter, generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
 import { DonationField, DonorType } from "@/utils/types";
-import { isValidCountry, isValidLocale } from "@/utils/validate";
+import {
+  isValidCountry,
+  isValidLocale,
+  isValidMetadataLocale,
+} from "@/utils/validate";
 
 import { DonorClientPage } from "./donor-client-page";
 import { DonorPageHead } from "./donor-page-head";
@@ -30,7 +34,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const params = await props.params;
 
-  if (!isValidLocale(params.locale)) return notFoundMetadata;
+  if (!isValidMetadataLocale(params.locale)) return notFoundMetadata;
   if (!isValidCountry(params.country)) return notFoundMetadata;
   setRequestLocale(params.locale);
 

--- a/src/app/[locale]/[country]/page.tsx
+++ b/src/app/[locale]/[country]/page.tsx
@@ -5,6 +5,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { AbsoluteMultipleColorsGradient } from "@/components/absolute-multiple-colors-gradient";
+import {
+  FormattedCompactCountryCurrency,
+  FormattedCountryCurrency,
+} from "@/components/browser-based-formatter";
 import { DonationStackedYears } from "@/components/charts/donation-stacked-years";
 import { BiggestDonationsHero } from "@/components/donations/biggest-donations-hero";
 import { DonorsHero } from "@/components/donors/donors-hero";
@@ -12,6 +16,7 @@ import { ExternalThanks } from "@/components/external-thanks";
 import { HistoryComponent } from "@/components/history-component";
 import { DetectedCountry } from "@/components/layout/detected-country";
 import { PartiesHero } from "@/components/parties/parties-hero";
+import { Translation } from "@/components/translation";
 import { YearsCards } from "@/components/years/years-cards";
 import { YearsHeader } from "@/components/years/years-header";
 import {
@@ -21,10 +26,6 @@ import {
 } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { Features, hasFeature } from "@/utils/features";
-import {
-  formatCompactCountryCurrency,
-  formatCountryCurrency,
-} from "@/utils/formatter";
 import { getBiggestDonors } from "@/utils/loader/biggest-donors";
 import { loadCountryData } from "@/utils/loader/country-data-loaders";
 import { getPartyYearsSums } from "@/utils/loader/party-years-sums";
@@ -149,14 +150,15 @@ export default async function YearsPage(
               >
                 <div className="flex items-center justify-between">
                   <span className="font-semibold">{previousYear}</span>
-                  {formatCountryCurrency(
-                    locale,
-                    Object.values(partySums[previousYear]).reduce(
-                      (all, stats) => all + stats.sum,
-                      0,
-                    ),
-                    countryConfig,
-                  )}
+                  {
+                    <FormattedCountryCurrency
+                      country={countryConfig}
+                      value={Object.values(partySums[previousYear]).reduce(
+                        (all, stats) => all + stats.sum,
+                        0,
+                      )}
+                    />
+                  }
                 </div>
               </Link>
             ) : null}
@@ -180,20 +182,27 @@ export default async function YearsPage(
               {countryConfig.knownPartyRequirements ? (
                 <>
                   <br />
-                  {tHome("what.threshold", {
-                    type:
-                      countryConfig.knownPartyRequirements.count === -1
-                        ? "sum"
-                        : countryConfig.knownPartyRequirements.sum === -1
-                          ? "count"
-                          : "both",
-                    count: countryConfig.knownPartyRequirements.count,
-                    sum: formatCompactCountryCurrency(
-                      locale,
-                      Math.max(0, countryConfig.knownPartyRequirements.sum),
-                      countryConfig,
-                    ),
-                  })}
+                  <Translation
+                    text={tHome.raw("what.threshold")}
+                    variables={{
+                      type:
+                        countryConfig.knownPartyRequirements.count === -1
+                          ? "sum"
+                          : countryConfig.knownPartyRequirements.sum === -1
+                            ? "count"
+                            : "both",
+                      count: countryConfig.knownPartyRequirements.count,
+                      sum: (
+                        <FormattedCompactCountryCurrency
+                          country={countryConfig}
+                          value={Math.max(
+                            0,
+                            countryConfig.knownPartyRequirements.sum,
+                          )}
+                        />
+                      ),
+                    }}
+                  />
                   <br />
                 </>
               ) : null}
@@ -293,11 +302,7 @@ export default async function YearsPage(
             })}
           </p>
 
-          <DonorsHero
-            country={countryConfig}
-            locale={locale}
-            biggestDonors={biggestDonors}
-          />
+          <DonorsHero country={countryConfig} biggestDonors={biggestDonors} />
 
           <BiggestDonationsHero
             country={countryConfig}

--- a/src/app/[locale]/[country]/party/[partyId]/donors/page.tsx
+++ b/src/app/[locale]/[country]/party/[partyId]/donors/page.tsx
@@ -14,7 +14,12 @@ import {
 import { getPartyYearsSums } from "@/utils/loader/party-years-sums";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
-import { isValidCountry, isValidLocale, isValidParty } from "@/utils/validate";
+import {
+  isValidCountry,
+  isValidLocale,
+  isValidMetadataLocale,
+  isValidParty,
+} from "@/utils/validate";
 
 import { PartyDonorsClientPage } from "./_components/party-donors-client-page";
 
@@ -23,7 +28,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const params = await props.params;
 
-  if (!isValidLocale(params.locale)) return notFoundMetadata;
+  if (!isValidMetadataLocale(params.locale)) return notFoundMetadata;
   if (!isValidCountry(params.country)) return notFoundMetadata;
   setRequestLocale(params.locale);
 

--- a/src/app/[locale]/[country]/party/[partyId]/layout.tsx
+++ b/src/app/[locale]/[country]/party/[partyId]/layout.tsx
@@ -7,6 +7,10 @@ import { notFound, redirect } from "next/navigation";
 import type { TabItem } from "@/components/tabs";
 
 import { AbsoluteMultipleColorsGradient } from "@/components/absolute-multiple-colors-gradient";
+import {
+  FormattedCountryCurrency,
+  FormattedNumber,
+} from "@/components/browser-based-formatter";
 import { PageHeader } from "@/components/layout/page-header";
 import { MetaCard } from "@/components/meta-card";
 import { LastModifiedSchema } from "@/components/schema";
@@ -19,7 +23,6 @@ import { THUMBNAIL_PREFIX } from "@/utils/config";
 import { findCorrectParty, getParty } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { Features, hasFeature } from "@/utils/features";
-import { formatCountryCurrency, formatNumber } from "@/utils/formatter";
 import {
   getPartyYearsSums,
   lastPartyStatsDonation,
@@ -201,27 +204,29 @@ export default async function PartyLayout(
               {hasFeature(countryConfig, Features.Donors) ? (
                 <MetaCard
                   title={t("donation_count")}
-                  value={formatNumber(locale, donationCount)}
+                  value={<FormattedNumber value={donationCount} />}
                 />
               ) : null}
               <MetaCard
                 title={t("sum")}
-                value={formatCountryCurrency(
-                  locale,
-                  donationSum,
-                  countryConfig,
-                )}
+                value={
+                  <FormattedCountryCurrency
+                    country={countryConfig}
+                    value={donationSum}
+                  />
+                }
               />
               {hasFeature(countryConfig, Features.Donors) &&
                 showExtendedMeta &&
                 donationCount > 1 && (
                   <MetaCard
                     title={t("average")}
-                    value={formatCountryCurrency(
-                      locale,
-                      donationSum / donationCount,
-                      countryConfig,
-                    )}
+                    value={
+                      <FormattedCountryCurrency
+                        country={countryConfig}
+                        value={donationSum / donationCount}
+                      />
+                    }
                   />
                 )}
             </div>

--- a/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars-content.tsx
+++ b/src/app/[locale]/[country]/tools/bar-chart-race/racing-bars-content.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useLocale } from "next-intl";
+
 import { parseAsString, useQueryState } from "nuqs";
 import { useMemo } from "react";
 
@@ -24,7 +24,6 @@ export const RacingBarsContent = ({
 }) => {
   const tCountries = useTranslations("countries");
   const tBarChartRace = useTranslations("bar_chart_race");
-  const locale = useLocale();
 
   const lastLegislativeYear = lastItem(
     countryConfig.legislativeYears ?? [
@@ -177,7 +176,6 @@ export const RacingBarsContent = ({
           years={validSelectedYears}
           donations={filteredDonations}
           groupByField={groupByField}
-          locale={locale}
           currency={countryConfig.currency}
           title={tBarChartRace("chart_title")}
           subtitle={tBarChartRace("chart_subtitle", {

--- a/src/app/[locale]/fun/page.tsx
+++ b/src/app/[locale]/fun/page.tsx
@@ -8,9 +8,9 @@ import type { ConstLocale } from "@/utils/locales";
 import type { StrictNamespacedTranslator } from "@/utils/translator";
 
 import { ErrorAlert, InfoAlert, SuccessAlert } from "@/components/alert";
+import { FormattedTwoDigitDate } from "@/components/browser-based-formatter";
 import { Article, ArticleSection } from "@/components/layout/article";
 import { NonCountryRootLayout } from "@/components/layout/non-country-root-layout";
-import { formatTwoDigitDate } from "@/utils/formatter";
 import { LOCALES } from "@/utils/locales";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -62,7 +62,7 @@ const FunFact = ({
     <ArticleSection title={title[locale]}>
       <div className="space-y-4">
         <h3 className="text-sm">
-          {formatTwoDigitDate(locale, new Date(date))}
+          <FormattedTwoDigitDate date={new Date(date)} />
         </h3>
         <p className="whitespace-pre-wrap">{text[locale]}</p>
         {children ? (

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -9,6 +9,10 @@ import type { Country, Currency } from "@/utils/countries";
 
 import { AbsoluteMultipleColorsGradient } from "@/components/absolute-multiple-colors-gradient";
 import {
+  FormattedCompactCurrency,
+  FormattedNumber,
+} from "@/components/browser-based-formatter";
+import {
   Article,
   ArticleSection,
   ArticleSectionColumn,
@@ -23,7 +27,6 @@ import { GITHUB_URL, THUMBNAIL_PREFIX } from "@/utils/config";
 import { COUNTRIES, COUNTRY_CONFIG, getCountryName } from "@/utils/countries";
 import { countryFlags } from "@/utils/country-flags";
 import { getCountryConfig } from "@/utils/data/get-country-config";
-import { formatCompactCurrency, formatNumber } from "@/utils/formatter";
 import { getPartyYearsSums } from "@/utils/loader/party-years-sums";
 import { LOCALES } from "@/utils/locales";
 import { baseOpenGraph, baseTwitter, generateAlternates } from "@/utils/meta";
@@ -145,19 +148,19 @@ export default async function RootPage(props: PageProps<"/[locale]">) {
                 <div className="text-center">
                   <MetaCard
                     title={tRoot("stats.countries")}
-                    value={formatNumber(locale, trackedCountries)}
+                    value={<FormattedNumber value={trackedCountries} />}
                   />
                 </div>
                 <div className="text-center">
                   <MetaCard
                     title={tRoot("stats.parties")}
-                    value={formatNumber(locale, trackedParties)}
+                    value={<FormattedNumber value={trackedParties} />}
                   />
                 </div>
                 <div className="text-center">
                   <MetaCard
                     title={tRoot("stats.donations")}
-                    value={formatNumber(locale, trackedDonations)}
+                    value={<FormattedNumber value={trackedDonations} />}
                   />
                 </div>
                 <div className="text-center">
@@ -210,11 +213,10 @@ export default async function RootPage(props: PageProps<"/[locale]">) {
                         {countryName}
                       </div>
                       <div className="text-xs text-slate-500 xl:text-sm dark:text-slate-300">
-                        {formatCompactCurrency(
-                          locale,
-                          sumPerCountry[countryId] ?? 0,
-                          config.currency,
-                        )}
+                        <FormattedCompactCurrency
+                          value={sumPerCountry[countryId] ?? 0}
+                          currency={config.currency}
+                        />
                       </div>
                     </div>
                   </Link>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -8,9 +8,10 @@ import { NextIntlClientProvider } from "next-intl";
 import { createContext, useEffect, useMemo, useState } from "react";
 
 import type { ClientMessages } from "@/utils/i18n-filter";
-import type { ConstLocale } from "@/utils/locales";
+import type { BrowserBasedLocale, ConstLocale } from "@/utils/locales";
 
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { makeBrand } from "@/utils/brand";
 import { SIDENAV_PERSISTENCE_KEY } from "@/utils/config";
 
 export const Providers = ({
@@ -40,11 +41,13 @@ export const Providers = ({
       locale={locale}
       messages={messages as unknown as Messages}
     >
-      <QueryClientProvider client={queryClient}>
-        <SidebarLocalStorageProvider>
-          <SearchDialogProvider>{children}</SearchDialogProvider>
-        </SidebarLocalStorageProvider>
-      </QueryClientProvider>
+      <BrowserBasedLocaleProvider locale={locale}>
+        <QueryClientProvider client={queryClient}>
+          <SidebarLocalStorageProvider>
+            <SearchDialogProvider>{children}</SearchDialogProvider>
+          </SidebarLocalStorageProvider>
+        </QueryClientProvider>
+      </BrowserBasedLocaleProvider>
     </NextIntlClientProvider>
   );
 };
@@ -76,6 +79,33 @@ export function SidebarLocalStorageProvider({ children }: PropsWithChildren) {
     </SidebarProvider>
   );
 }
+
+export const BrowserBasedLocaleContext =
+  createContext<BrowserBasedLocale | null>(null);
+
+export const BrowserBasedLocaleProvider = ({
+  children,
+  locale,
+}: PropsWithChildren<{ locale: ConstLocale }>) => {
+  // We use the base locale as the initial state to ensure hydration matches the server-side render.
+  const [browserBasedLocale, setBrowserBasedLocale] =
+    useState<BrowserBasedLocale>(() => makeBrand<BrowserBasedLocale>(locale));
+
+  useEffect(() => {
+    // navigator is only available in the browser.
+    const navigatorLanguage = navigator.language;
+
+    if (navigatorLanguage.startsWith(locale)) {
+      setBrowserBasedLocale(makeBrand<BrowserBasedLocale>(navigatorLanguage));
+    }
+  }, [locale]);
+
+  return (
+    <BrowserBasedLocaleContext.Provider value={browserBasedLocale}>
+      {children}
+    </BrowserBasedLocaleContext.Provider>
+  );
+};
 
 type SearchDialogContextValue = {
   isOpen: boolean;

--- a/src/components/browser-based-formatter.tsx
+++ b/src/components/browser-based-formatter.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { CountryConfig } from "@/types/country-config";
+import type { Currency } from "@/utils/countries";
+
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
+import {
+  formatCompactCountryCurrency,
+  formatCompactCurrency,
+  formatCountryCurrency,
+  formatNumber,
+  formatTwoDigitDate,
+} from "@/utils/formatter";
+
+export const FormattedTwoDigitDate = ({ date }: { date: Date }) => {
+  const browserBasedLocale = useBrowserBasedLocale();
+
+  return formatTwoDigitDate(browserBasedLocale, date);
+};
+
+export const FormattedCompactCurrency = ({
+  value,
+  currency,
+}: {
+  value: number;
+  currency: Currency;
+}) => {
+  const browserBasedLocale = useBrowserBasedLocale();
+
+  return formatCompactCurrency(browserBasedLocale, value, currency);
+};
+
+export const FormattedCompactCountryCurrency = ({
+  value,
+  country,
+}: {
+  value: number;
+  country: CountryConfig;
+}) => {
+  const browserBasedLocale = useBrowserBasedLocale();
+
+  return formatCompactCountryCurrency(browserBasedLocale, value, country);
+};
+
+export const FormattedCountryCurrency = ({
+  value,
+  country,
+}: {
+  value: number;
+  country: CountryConfig;
+}) => {
+  const browserBasedLocale = useBrowserBasedLocale();
+
+  return formatCountryCurrency(browserBasedLocale, value, country);
+};
+
+export const FormattedNumber = ({ value }: { value: number }) => {
+  const browserBasedLocale = useBrowserBasedLocale();
+
+  return formatNumber(browserBasedLocale, value);
+};

--- a/src/components/charts/donation-per-month-chart.tsx
+++ b/src/components/charts/donation-per-month-chart.tsx
@@ -1,12 +1,11 @@
 "use client";
 import type { BarSeriesOption, EChartsOption } from "echarts";
 
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation, ReceiverId } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { PartyField } from "@/types/party";
 import { partyColor } from "@/utils/color";
@@ -79,7 +78,7 @@ const DonationBarChart = ({
   limitToFirstDateYear?: boolean;
   resolution?: DonationPerMonthResolution;
 }) => {
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { backgroundColor, isMobile, isDark } = useChart();
 
   const leftmostYear = limitToFirstDateYear
@@ -219,8 +218,8 @@ const DonationBarChart = ({
         filterMode: "none",
         labelFormatter: (value) =>
           resolution === "year"
-            ? formatYear(locale, value)
-            : formatTwoDigitDate(locale, value),
+            ? formatYear(browserBasedLocale, value)
+            : formatTwoDigitDate(browserBasedLocale, value),
         bottom: 20,
         // zoom to min 5 months or 3 years
         minValueSpan:
@@ -239,15 +238,15 @@ const DonationBarChart = ({
           formatter(params) {
             if (params.axisDimension === "y") {
               return formatCompactCountryCurrency(
-                locale,
+                browserBasedLocale,
                 params.value as number,
                 country,
               );
             } else if (params.axisDimension === "x") {
               const date = new Date(params.value);
               return resolution === "year"
-                ? formatYear(locale, date)
-                : formatMonthYear(locale, date);
+                ? formatYear(browserBasedLocale, date)
+                : formatMonthYear(browserBasedLocale, date);
             }
 
             return "";
@@ -271,7 +270,7 @@ const DonationBarChart = ({
           const party = getParty(country, param.seriesName as ReceiverId);
 
           lines.push(
-            `${param.marker} ${party[PartyField.Short]}: ${formatCountryCurrency(locale, sum, country)}`,
+            `${param.marker} ${party[PartyField.Short]}: ${formatCountryCurrency(browserBasedLocale, sum, country)}`,
           );
         }
 
@@ -280,10 +279,10 @@ const DonationBarChart = ({
         const date = (params[0].data as [Date])[0] as Date;
         const dateLabel =
           resolution === "year"
-            ? formatYear(locale, date)
-            : formatMonthYear(locale, date);
+            ? formatYear(browserBasedLocale, date)
+            : formatMonthYear(browserBasedLocale, date);
 
-        return `<div class="mb-1 text-sm leading-none text-grey-500">${dateLabel}</div><div class="font-semibold text-lg">${formatCountryCurrency(locale, allSum, country)}</div>${lines.join("<br/>")}`;
+        return `<div class="mb-1 text-sm leading-none text-grey-500">${dateLabel}</div><div class="font-semibold text-lg">${formatCountryCurrency(browserBasedLocale, allSum, country)}</div>${lines.join("<br/>")}`;
       },
     },
     xAxis: {
@@ -300,7 +299,7 @@ const DonationBarChart = ({
         type: "value",
         axisLabel: {
           formatter: (value) =>
-            formatCompactCountryCurrency(locale, value, country),
+            formatCompactCountryCurrency(browserBasedLocale, value, country),
         },
       },
     ],

--- a/src/components/charts/donation-stacked-years.tsx
+++ b/src/components/charts/donation-stacked-years.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { getCountryName } from "@/utils/countries";
@@ -34,6 +35,7 @@ export const DonationStackedYears = ({
   const tStackedYears = useTranslations("stacked_years");
   const tCountries = useTranslations("countries");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const router = useRouter();
   const { backgroundColor, isMobile, isDark } = useChart();
 
@@ -117,7 +119,7 @@ export const DonationStackedYears = ({
       },
       trigger: "axis",
       valueFormatter: (value) =>
-        formatCountryCurrency(locale, value as number, country),
+        formatCountryCurrency(browserBasedLocale, value as number, country),
     },
     xAxis: [
       {
@@ -125,7 +127,7 @@ export const DonationStackedYears = ({
         triggerEvent: true,
         axisLabel: {
           formatter: (value) =>
-            formatCompactCountryCurrency(locale, value, country),
+            formatCompactCountryCurrency(browserBasedLocale, value, country),
         },
       },
     ],

--- a/src/components/charts/donation-state-map.tsx
+++ b/src/components/charts/donation-state-map.tsx
@@ -1,13 +1,12 @@
 "use client";
 import type { EChartsOption } from "echarts";
 
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Countries } from "@/utils/countries";
 import type { Donation, ReceiverId } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -36,7 +35,7 @@ export const DonationStateMap = ({
   donations: Donation[];
 }) => {
   const t = useTranslations();
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { isMobile, backgroundColor, isDark } = useChart();
   const countryCode = country.code;
   const isEu = country.id === Country.europeanunion;
@@ -94,7 +93,7 @@ export const DonationStateMap = ({
       right: 20,
       orient: isMobile ? "horizontal" : "vertical",
       formatter: (value) =>
-        formatCountryCurrency(locale, value as number, country),
+        formatCountryCurrency(browserBasedLocale, value as number, country),
       inRange: {
         color: [
           "#fff",
@@ -156,7 +155,7 @@ export const DonationStateMap = ({
 
             tooltipContent += `<div class="flex justify-between"><div class="font-semibold leading-normal">${t(
               "sum",
-            )}</div>${formatCountryCurrency(locale, Number.isNaN(value) ? 0 : value, country)}</div>`;
+            )}</div>${formatCountryCurrency(browserBasedLocale, Number.isNaN(value) ? 0 : value, country)}</div>`;
 
             const donations = (
               Object.entries(statePartyDonations[params.name] ?? {}) as [
@@ -174,7 +173,7 @@ export const DonationStateMap = ({
                     )}"></div>
                     <div>${formatPartyShortName(country, party)}</div>
                   </div> 
-                  ${formatCountryCurrency(locale, sum, country)}
+                  ${formatCountryCurrency(browserBasedLocale, sum, country)}
                 </div>`;
               });
 

--- a/src/components/charts/donation-state-sankey.tsx
+++ b/src/components/charts/donation-state-sankey.tsx
@@ -2,12 +2,11 @@
 import type { EChartsOption } from "echarts";
 import type { SankeyNodeItemOption } from "echarts/types/src/chart/sankey/SankeySeries.js";
 
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation, ReceiverId } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -42,7 +41,7 @@ export const DonationStateSankey = ({
   donations: Donation[];
 }) => {
   const t = useTranslations();
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { backgroundColor } = useChart();
 
   const isEu = country.id === Country.europeanunion;
@@ -100,12 +99,12 @@ export const DonationStateSankey = ({
       confine: true,
       show: true,
       valueFormatter: (value) =>
-        formatCountryCurrency(locale, value as number, country),
+        formatCountryCurrency(browserBasedLocale, value as number, country),
       formatter: (params) => {
         if (Array.isArray(params)) return "";
 
         const formattedCurrency = formatCountryCurrency(
-          locale,
+          browserBasedLocale,
           params.value as number,
           country,
         );

--- a/src/components/charts/donation-sum-chart.tsx
+++ b/src/components/charts/donation-sum-chart.tsx
@@ -1,12 +1,11 @@
 "use client";
 import type { EChartsOption, LineSeriesOption } from "echarts";
 
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation, ReceiverId } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -115,7 +114,7 @@ const DonationTimeseriesChart = ({
   subtitle: string;
   limitToFirstDateYear?: boolean;
 }) => {
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { backgroundColor, isMobile, isDark } = useChart();
   const tYears = useClientTranslations("years");
 
@@ -257,7 +256,8 @@ const DonationTimeseriesChart = ({
         type: "slider",
         xAxisIndex: [0],
         filterMode: "none",
-        labelFormatter: (value) => formatTwoDigitDate(locale, value),
+        labelFormatter: (value) =>
+          formatTwoDigitDate(browserBasedLocale, value),
         bottom: 20,
         // zoom to min 5 days
         minValueSpan: 1000 * 60 * 60 * 24 * 5,
@@ -273,12 +273,15 @@ const DonationTimeseriesChart = ({
           formatter: (params) => {
             if (params.axisDimension === "y") {
               return formatCompactCountryCurrency(
-                locale,
+                browserBasedLocale,
                 params.value as number,
                 country,
               );
             } else if (params.axisDimension === "x") {
-              return formatMonthYear(locale, new Date(params.value));
+              return formatMonthYear(
+                browserBasedLocale,
+                new Date(params.value),
+              );
             }
 
             return "";
@@ -306,11 +309,11 @@ const DonationTimeseriesChart = ({
           const delta = sum - previousPartyValue;
 
           const party = getParty(country, param.seriesName as ReceiverId);
-          line += `${param.marker} ${party[PartyField.Short]}: ${formatCountryCurrency(locale, sum, country)}`;
+          line += `${param.marker} ${party[PartyField.Short]}: ${formatCountryCurrency(browserBasedLocale, sum, country)}`;
 
           // only add delta if there is a change
           if (delta > 0) {
-            line += ` (+${formatCountryCurrency(locale, delta, country)})`;
+            line += ` (+${formatCountryCurrency(browserBasedLocale, delta, country)})`;
           }
 
           lines.push(line);
@@ -319,7 +322,7 @@ const DonationTimeseriesChart = ({
         if (!lines.length) return "";
 
         return `<div style="font-size:14px;color:#666;font-weight:600;line-height:1;margin-bottom:5px">${formatDate(
-          locale,
+          browserBasedLocale,
           (params[0].data as LineDatum)[0],
         )}</div>${lines.join("<br/>")}`;
       },
@@ -337,7 +340,7 @@ const DonationTimeseriesChart = ({
         type: "value",
         axisLabel: {
           formatter: (value) =>
-            formatCompactCountryCurrency(locale, value, country),
+            formatCompactCountryCurrency(browserBasedLocale, value, country),
         },
       },
     ],
@@ -361,7 +364,7 @@ const DonationTimeseriesChart = ({
     filteredYearDonationCount > 0
       ? tYears("no_date_omitted", {
           sum: formatCompactCountryCurrency(
-            locale,
+            browserBasedLocale,
             filteredYearDonationSum,
             country,
           ),
@@ -407,7 +410,7 @@ export const DonationStackedTimeseriesChart = ({
   limitToFirstDateYear?: boolean;
   donationsHaveYearsOnly?: boolean;
 }) => {
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { backgroundColor, isMobile, isDark } = useChart();
 
   const leftmostYear = limitToFirstDateYear
@@ -582,7 +585,8 @@ export const DonationStackedTimeseriesChart = ({
         type: "slider",
         xAxisIndex: [0],
         filterMode: "none",
-        labelFormatter: (value) => formatTwoDigitDate(locale, value),
+        labelFormatter: (value) =>
+          formatTwoDigitDate(browserBasedLocale, value),
         bottom: 20,
         minValueSpan,
       },
@@ -597,12 +601,15 @@ export const DonationStackedTimeseriesChart = ({
           formatter: (params) => {
             if (params.axisDimension === "y") {
               return formatCompactCountryCurrency(
-                locale,
+                browserBasedLocale,
                 params.value as number,
                 country,
               );
             } else if (params.axisDimension === "x") {
-              return formatMonthYear(locale, new Date(params.value));
+              return formatMonthYear(
+                browserBasedLocale,
+                new Date(params.value),
+              );
             }
 
             return "";
@@ -630,11 +637,11 @@ export const DonationStackedTimeseriesChart = ({
           const delta = sum - previousPartyValue;
 
           const party = getParty(country, param.seriesName as ReceiverId);
-          line += `${param.marker} <span class="font-medium">${party[PartyField.Short]}</span>: ${formatCountryCurrency(locale, sum, country)}`;
+          line += `${param.marker} <span class="font-medium">${party[PartyField.Short]}</span>: ${formatCountryCurrency(browserBasedLocale, sum, country)}`;
 
           // only add delta if there is a change
           if (delta > 0) {
-            line += ` (+${formatCountryCurrency(locale, delta, country)})`;
+            line += ` (+${formatCountryCurrency(browserBasedLocale, delta, country)})`;
           }
 
           lines.push(line);
@@ -644,8 +651,8 @@ export const DonationStackedTimeseriesChart = ({
 
         const date = (params[0].data as LineDatum)[0];
         const formattedDate = donationsHaveYearsOnly
-          ? formatYear(locale, date)
-          : formatDate(locale, date);
+          ? formatYear(browserBasedLocale, date)
+          : formatDate(browserBasedLocale, date);
 
         return `<div class="text-sm font-semibold mb-2">${formattedDate}</div>${lines.join("<br/>")}`;
       },
@@ -666,7 +673,7 @@ export const DonationStackedTimeseriesChart = ({
         type: "value",
         axisLabel: {
           formatter: (value) =>
-            formatCompactCountryCurrency(locale, value, country),
+            formatCompactCountryCurrency(browserBasedLocale, value, country),
         },
       },
     ],

--- a/src/components/charts/donation-year-scatter-plot.tsx
+++ b/src/components/charts/donation-year-scatter-plot.tsx
@@ -13,6 +13,7 @@ import type { Party } from "@/types/party";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { TextPartyLink } from "@/components/parties/text-party-link";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -42,6 +43,7 @@ export const DonationYearScatterPlot = ({
 }) => {
   const t = useTranslations();
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { backgroundColor } = useChart();
 
   const partyIds = new Set(parties.map((p) => p[PartyField.Id]));
@@ -145,7 +147,8 @@ export const DonationYearScatterPlot = ({
         max: largestAmount,
         min: smallestAmount,
         axisLabel: {
-          formatter: (data) => formatCountryCurrency(locale, data, country),
+          formatter: (data) =>
+            formatCountryCurrency(browserBasedLocale, data, country),
         },
       });
       series.push({
@@ -183,7 +186,7 @@ export const DonationYearScatterPlot = ({
       </div></div>`;
 
         const formattedCurrency = formatCountryCurrency(
-          locale,
+          browserBasedLocale,
           amount,
           country,
         );
@@ -211,7 +214,7 @@ ${partyPart}
             text={t.raw("overview.scatter.span")}
             variables={{
               biggestSpanAmount: formatCountryCurrency(
-                locale,
+                browserBasedLocale,
                 biggestSpan,
                 country,
               ),

--- a/src/components/charts/donations-pie-chart.tsx
+++ b/src/components/charts/donations-pie-chart.tsx
@@ -9,6 +9,7 @@ import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ReceiverId } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -30,6 +31,7 @@ export const DonationsPieChart = ({
   const t = useTranslations();
   const tCountries = useTranslations("countries");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const router = useRouter();
   const { backgroundColor, isMobile } = useChart();
   const partySums: Record<string, number> = {};
@@ -64,7 +66,7 @@ export const DonationsPieChart = ({
 
           if (params.treeAncestors.length === 2) {
             // is "root" level
-            return `{name|${params.name}}\n{value|${formatCountryCurrency(locale, params.value as number, country)}}`;
+            return `{name|${params.name}}\n{value|${formatCountryCurrency(browserBasedLocale, params.value as number, country)}}`;
           }
 
           return ``;
@@ -98,7 +100,7 @@ export const DonationsPieChart = ({
       confine: true,
       trigger: "item",
       valueFormatter: (value) =>
-        formatCountryCurrency(locale, value as number, country),
+        formatCountryCurrency(browserBasedLocale, value as number, country),
     },
     series: [
       {
@@ -116,7 +118,7 @@ export const DonationsPieChart = ({
         label: {
           position: "insideTopLeft",
           formatter: (params) => {
-            return `{amount|${formatCountryCurrency(locale, params.value as number, country)}}`;
+            return `{amount|${formatCountryCurrency(browserBasedLocale, params.value as number, country)}}`;
           },
           rich: {
             amount: {

--- a/src/components/charts/echarts-racing-bars.tsx
+++ b/src/components/charts/echarts-racing-bars.tsx
@@ -2,13 +2,14 @@
 import type { BarSeriesOption, EChartsOption } from "echarts";
 
 import { Download, Pause, Play, RotateCcw } from "lucide-react";
+import { useLocale } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { CountryConfig } from "@/types/country-config";
 import type { Currency } from "@/utils/countries";
-import type { ConstLocale } from "@/utils/locales";
 
 import { ExpandableReactEchart } from "@/components/charts/expandable-react-echart";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import {
@@ -24,7 +25,6 @@ interface EChartsRacingBarsProps {
   donations: Donation[];
   years: string[];
   groupByField: DonationField.DonorName | DonationField.Receiver;
-  locale: ConstLocale;
   currency: Currency;
   title: string;
   subtitle: string;
@@ -45,12 +45,13 @@ export const EChartsRacingBars = ({
   donations,
   years,
   groupByField,
-  locale,
   currency,
   title,
   subtitle,
   totalRuntimeMs = DEFAULT_TOTAL_RUNTIME_MS,
 }: EChartsRacingBarsProps) => {
+  const browserBasedLocale = useBrowserBasedLocale();
+  const locale = useLocale();
   const partiesById = useMemo(() => {
     return Object.fromEntries(
       countryConfig.parties.map((p) => [p[PartyField.Id], p]),
@@ -268,7 +269,11 @@ export const EChartsRacingBars = ({
                   (g) => g.groupName === groupName,
                 );
                 const total = group?.total || 0;
-                return formatCompactCurrency(locale, total, currency);
+                return formatCompactCurrency(
+                  browserBasedLocale,
+                  total,
+                  currency,
+                );
               },
               fontSize: 14,
               color: "#fff",
@@ -301,7 +306,7 @@ export const EChartsRacingBars = ({
               const groupName = groupNames[params.dataIndex];
               const group = sortedGroups.find((g) => g.groupName === groupName);
               const total = group?.total || 0;
-              return formatCompactCurrency(locale, total, currency);
+              return formatCompactCurrency(browserBasedLocale, total, currency);
             },
             fontSize: 14,
             color: "#fff",
@@ -316,7 +321,7 @@ export const EChartsRacingBars = ({
     const currentDate =
       currentDateIndex >= 0 ? sortedDates[currentDateIndex] : null;
     const formattedCurrentDate = currentDate
-      ? formatTwoDigitDate(locale, new Date(currentDate))
+      ? formatTwoDigitDate(browserBasedLocale, new Date(currentDate))
       : "";
 
     return {
@@ -400,12 +405,15 @@ export const EChartsRacingBars = ({
           style: {
             text: `${
               sortedDates[0]
-                ? formatTwoDigitDate(locale, new Date(sortedDates[0]))
+                ? formatTwoDigitDate(
+                    browserBasedLocale,
+                    new Date(sortedDates[0]),
+                  )
                 : ""
             } - ${
               sortedDates[sortedDates.length - 1]
                 ? formatTwoDigitDate(
-                    locale,
+                    browserBasedLocale,
                     new Date(sortedDates[sortedDates.length - 1]),
                   )
                 : ""
@@ -465,7 +473,7 @@ export const EChartsRacingBars = ({
         },
         axisLabel: {
           formatter: (value: number) =>
-            formatCompactCurrency(locale, value, currency),
+            formatCompactCurrency(browserBasedLocale, value, currency),
           color: "rgba(255, 255, 255, 0.7)",
           fontSize: 14,
         },
@@ -756,7 +764,10 @@ export const EChartsRacingBars = ({
           {isRecording ? (
             <span className="mr-4 tabular-nums">
               {t("bar_chart_race.rendering", {
-                percentage: formatPercentFormat(locale, recordingProgress),
+                percentage: formatPercentFormat(
+                  browserBasedLocale,
+                  recordingProgress,
+                ),
               })}
             </span>
           ) : null}

--- a/src/components/charts/expandable-react-echart.tsx
+++ b/src/components/charts/expandable-react-echart.tsx
@@ -2,12 +2,12 @@
 import type { LucideIcon } from "lucide-react";
 
 import { Expand, X, ZoomOut } from "lucide-react";
-import { useLocale } from "next-intl";
 import { type JSX, useCallback, useRef, useState } from "react";
 
 import type { CountryConfig } from "@/types/country-config";
 
 import { PageLogo } from "@/components/layout/page-logo";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { isNotNullandNotUndefined } from "@/utils/array";
 import {
@@ -57,7 +57,7 @@ export const ExpandableReactEchart = ({
 }): JSX.Element => {
   const t = useTranslations();
   const tChart = useTranslations("chart");
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isZoomed, setIsZoomed] = useState(false);
@@ -142,7 +142,7 @@ export const ExpandableReactEchart = ({
           option={option}
           settings={settings}
           theme={theme}
-          locale={locale}
+          locale={browserBasedLocale}
           onZrClick={onZrClick}
           onClick={onClick}
           onZoom={handleZoom}
@@ -153,7 +153,7 @@ export const ExpandableReactEchart = ({
           <div className="opacity-80">
             {t("footer.build", {
               date: formatTwoDigitDate(
-                locale,
+                browserBasedLocale,
                 new Date(getBuild(country.id).t),
               ),
             })}
@@ -161,7 +161,7 @@ export const ExpandableReactEchart = ({
             {[
               t("over_min_public_amount", {
                 amount: formatCompactCountryCurrency(
-                  locale,
+                  browserBasedLocale,
                   country.minPublicDonationAmount,
                   country,
                 ),
@@ -176,7 +176,7 @@ export const ExpandableReactEchart = ({
                           : "both",
                     count: country.knownPartyRequirements.count,
                     sum: formatCompactCountryCurrency(
-                      locale,
+                      browserBasedLocale,
                       Math.max(0, country.knownPartyRequirements.sum),
                       country,
                     ),

--- a/src/components/charts/loading-donation-years-treemap.tsx
+++ b/src/components/charts/loading-donation-years-treemap.tsx
@@ -9,6 +9,7 @@ import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation, ReceiverId } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -42,6 +43,7 @@ export const LoadedDonationYearsTreemap = ({
   const t = useTranslations();
   const tCommon = useTranslations("common");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const yearsSet = new Set<string>(years);
   const partiesSet = new Set<Party>(parties);
@@ -113,7 +115,7 @@ export const LoadedDonationYearsTreemap = ({
           formatter(params) {
             return (
               (hasPartyLabel ? `{name|${party[PartyField.Short]}}\n` : "") +
-              `{value|${formatCountryCurrency(locale, params.value as number, country)}}`
+              `{value|${formatCountryCurrency(browserBasedLocale, params.value as number, country)}}`
             );
           },
           rich: {
@@ -145,7 +147,7 @@ export const LoadedDonationYearsTreemap = ({
         <div>${party[PartyField.Short]}</div>
       </div></div>`;
 
-            return `<div class="max-w-60 text-wrap">${partyPart}<div>${formatCountryCurrency(locale, params.value as number, country)}</div></div>`;
+            return `<div class="max-w-60 text-wrap">${partyPart}<div>${formatCountryCurrency(browserBasedLocale, params.value as number, country)}</div></div>`;
           },
         },
       });
@@ -199,7 +201,7 @@ export const LoadedDonationYearsTreemap = ({
 
         if (treeAncestors.length === 2) {
           // is "root" level
-          content = `<div class="font-semibold">${params.name}</div> <div>${formatCountryCurrency(locale, params.value as number, country)}</div>`;
+          content = `<div class="font-semibold">${params.name}</div> <div>${formatCountryCurrency(browserBasedLocale, params.value as number, country)}</div>`;
         }
 
         return `<div class="max-w-60 text-wrap">${content}</div>`;
@@ -231,7 +233,7 @@ export const LoadedDonationYearsTreemap = ({
 
           if (treeAncestors.length === 2) {
             // is "root" level
-            return `{name|${getDonorName(params.name, tCommon)}} {value|${formatCountryCurrency(locale, params.value as number, country)}}`;
+            return `{name|${getDonorName(params.name, tCommon)}} {value|${formatCountryCurrency(browserBasedLocale, params.value as number, country)}}`;
           }
 
           return ``;

--- a/src/components/charts/loading-donor-receiver-histogram.tsx
+++ b/src/components/charts/loading-donor-receiver-histogram.tsx
@@ -2,12 +2,11 @@
 import type { EChartsOption } from "echarts";
 import type { CallbackDataParams } from "echarts/types/dist/shared";
 
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -34,7 +33,7 @@ export const LoadedDonorReceiverHistogram = ({
   years?: string[];
 }) => {
   const t = useTranslations();
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const yearsSet = new Set<string>(years);
   const partiesSet = new Set<Party>(parties);
@@ -127,8 +126,8 @@ export const LoadedDonorReceiverHistogram = ({
         const donorCount = data[1] || 0;
 
         return t("donors.histogram.tooltip", {
-          donors: formatNumber(locale, donorCount),
-          parties: formatNumber(locale, receiversCount),
+          donors: formatNumber(browserBasedLocale, donorCount),
+          parties: formatNumber(browserBasedLocale, receiversCount),
         });
       },
     },
@@ -142,7 +141,7 @@ export const LoadedDonorReceiverHistogram = ({
         // type: "log",
         // logBase: 4,
         axisLabel: {
-          formatter: (value: number) => formatNumber(locale, value),
+          formatter: (value: number) => formatNumber(browserBasedLocale, value),
         },
         minorSplitLine: {
           show: true,

--- a/src/components/charts/loading-donor-types-treemap.tsx
+++ b/src/components/charts/loading-donor-types-treemap.tsx
@@ -9,6 +9,7 @@ import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation, ReceiverId } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useChart } from "@/hooks/use-chart";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
@@ -38,6 +39,7 @@ export const LoadedDonorTypeTreemap = ({
 }) => {
   const t = useTranslations();
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const yearsSet = new Set<string>(years);
   const partiesSet = new Set<Party>(parties);
@@ -117,7 +119,7 @@ export const LoadedDonorTypeTreemap = ({
             label: {
               position: "insideTopLeft",
               formatter(params) {
-                return `{name|${donor}}\n{value|${formatCountryCurrency(locale, params.value as number, country)}}`;
+                return `{name|${donor}}\n{value|${formatCountryCurrency(browserBasedLocale, params.value as number, country)}}`;
               },
               itemStyle: {
                 color: donorTypeColor(type as unknown as DonorType),
@@ -147,7 +149,7 @@ export const LoadedDonorTypeTreemap = ({
           formatter(params) {
             return (
               (hasPartyLabel ? `{name|${party[PartyField.Short]}}\n` : "") +
-              `{value|${formatCountryCurrency(locale, params.value as number, country)}}`
+              `{value|${formatCountryCurrency(browserBasedLocale, params.value as number, country)}}`
             );
           },
           rich: {
@@ -179,7 +181,7 @@ export const LoadedDonorTypeTreemap = ({
         <div>${party[PartyField.Short]}</div>
       </div></div>`;
 
-            return `<div class="max-w-60 text-wrap">${partyPart}<div>${formatCountryCurrency(locale, params.value as number, country)}</div></div>`;
+            return `<div class="max-w-60 text-wrap">${partyPart}<div>${formatCountryCurrency(browserBasedLocale, params.value as number, country)}</div></div>`;
           },
         },
       });
@@ -235,13 +237,13 @@ export const LoadedDonorTypeTreemap = ({
           const categoryName = t(
             `donor_type.${params.name as unknown as DonorType}`,
           );
-          content = `<div class="font-semibold">${categoryName}</div> <div>${formatCountryCurrency(locale, params.value as number, country)}</div>`;
+          content = `<div class="font-semibold">${categoryName}</div> <div>${formatCountryCurrency(browserBasedLocale, params.value as number, country)}</div>`;
         }
 
         if (treeAncestors.length === 3) return "";
 
         if (treeAncestors.length === 4) {
-          content = `<div class="font-semibold">${params.name}</div> <div>${formatCountryCurrency(locale, params.value as number, country)}</div>`;
+          content = `<div class="font-semibold">${params.name}</div> <div>${formatCountryCurrency(browserBasedLocale, params.value as number, country)}</div>`;
         }
 
         return `<div class="max-w-60 text-wrap">${content}</div>`;
@@ -273,7 +275,7 @@ export const LoadedDonorTypeTreemap = ({
 
           if (treeAncestors.length === 2) {
             // is "root" level
-            return `{name|${t(`donor_type.${params.name as unknown as DonorType}`)}} {value|${formatCountryCurrency(locale, params.value as number, country)}}`;
+            return `{name|${t(`donor_type.${params.name as unknown as DonorType}`)}} {value|${formatCountryCurrency(browserBasedLocale, params.value as number, country)}}`;
           }
 
           return ``;

--- a/src/components/charts/stacked-party-line.tsx
+++ b/src/components/charts/stacked-party-line.tsx
@@ -1,12 +1,14 @@
+"use client";
+
 import type { CountryConfig } from "@/types/country-config";
 import type {
   PartyStats,
   PartyYearsSums,
 } from "@/utils/loader/party-years-sums";
-import type { ConstLocale } from "@/utils/locales";
 import type { ReceiverId } from "@/utils/types";
 
 import { AbsoluteMultipleColorsGradient } from "@/components/absolute-multiple-colors-gradient";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { cn } from "@/lib/utils";
 import { PartyField } from "@/types/party";
 import { partyColor } from "@/utils/color";
@@ -16,17 +18,15 @@ import { formatCountryCurrency } from "@/utils/formatter";
 export const StackedPartyDonations = ({
   years,
   country,
-  // TODO: handle donator support
-  locale,
   partyYearsSums,
   direction = "horizontal",
 }: {
   country: CountryConfig;
   years: string[];
-  locale: ConstLocale;
   partyYearsSums: PartyYearsSums;
   direction?: "horizontal" | "vertical";
 }) => {
+  const browserBasedLocale = useBrowserBasedLocale();
   const sums: Record<ReceiverId, number> = {};
   let sum = 0;
 
@@ -59,7 +59,7 @@ export const StackedPartyDonations = ({
       {sortedSums.map(([party, data]) => (
         <div
           key={party}
-          title={`${getParty(country, party)[PartyField.Short]}: ${formatCountryCurrency(locale, data, country)}`}
+          title={`${getParty(country, party)[PartyField.Short]}: ${formatCountryCurrency(browserBasedLocale, data, country)}`}
           style={{
             backgroundColor: partyColor(party, country),
             [direction === "horizontal" ? "width" : "height"]:

--- a/src/components/donations/biggest-donations-hero.tsx
+++ b/src/components/donations/biggest-donations-hero.tsx
@@ -8,6 +8,7 @@ import { DonorLink } from "@/components/donors/donor-link";
 import { FormatAnd } from "@/components/formatter";
 import { TextPartyLink } from "@/components/parties/text-party-link";
 import { Translation } from "@/components/translation";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { getCountryName } from "@/utils/countries";
 import { donationYear } from "@/utils/date";
@@ -26,6 +27,7 @@ export const BiggestDonationsHero = ({
   const tCountries = useTranslations("countries");
   const tCommon = useTranslations("common");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   if (!biggestDonations.length) return null;
 
@@ -40,7 +42,7 @@ export const BiggestDonationsHero = ({
           minYear: country.minYear,
           country: getCountryName(country, tCountries),
           amount: formatCountryCurrency(
-            locale,
+            browserBasedLocale,
             biggestDonation[DonationField.Amount],
             country,
           ),
@@ -67,7 +69,7 @@ export const BiggestDonationsHero = ({
                   text={tBiggestDonations.raw("list")}
                   variables={{
                     amount: formatCountryCurrency(
-                      locale,
+                      browserBasedLocale,
                       donation[DonationField.Amount],
                       country,
                     ),

--- a/src/components/donations/donation-history-date.tsx
+++ b/src/components/donations/donation-history-date.tsx
@@ -1,19 +1,18 @@
 "use client";
-import { useLocale } from "next-intl";
-
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { dateDiffInDays, donationYear } from "@/utils/date";
 import { formatDate, formatRelativeDate } from "@/utils/formatter";
 import { DonationField } from "@/utils/types";
 
 export const DonationHistoryDate = ({ date }: { date: string }) => {
   const now = Date.now();
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   if (date === donationYear({ [DonationField.Date]: date }))
     return <div className="shrink-0 text-sm">{date}</div>;
 
   const dateDate = new Date(date);
-  const fmtDate = formatDate(locale, dateDate);
+  const fmtDate = formatDate(browserBasedLocale, dateDate);
   const dateDiff = dateDiffInDays(new Date(now), dateDate);
 
   return (
@@ -22,7 +21,7 @@ export const DonationHistoryDate = ({ date }: { date: string }) => {
 
       {dateDiff !== 0 ? (
         <span className="hidden lg:inline">
-          &nbsp;({formatRelativeDate(locale, dateDiff, "days")})
+          &nbsp;({formatRelativeDate(browserBasedLocale, dateDiff, "days")})
         </span>
       ) : null}
     </div>

--- a/src/components/donations/donation-history-item.tsx
+++ b/src/components/donations/donation-history-item.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useLocale } from "next-intl";
 
 import type { CountryConfig } from "@/types/country-config";
@@ -6,6 +8,7 @@ import type { ReceiverId } from "@/utils/types";
 import { DonorLink } from "@/components/donors/donor-link";
 import { PartyDot } from "@/components/parties/party-dot";
 import { PartyLink } from "@/components/parties/party-link";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { formatCountryCurrency } from "@/utils/formatter";
 
 import { DynamicDonationHistoryDate } from "./dynamic-donation-history-date";
@@ -24,7 +27,8 @@ export const DonationHistoryItem = ({
   country: CountryConfig;
 }) => {
   const locale = useLocale();
-  const fmtAmount = formatCountryCurrency(locale, amount, country);
+  const browserBasedLocale = useBrowserBasedLocale();
+  const fmtAmount = formatCountryCurrency(browserBasedLocale, amount, country);
 
   return (
     <li

--- a/src/components/donations/donation-origin.tsx
+++ b/src/components/donations/donation-origin.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useLocale } from "next-intl";
 import { useState } from "react";
 
 import type { CountryConfig } from "@/types/country-config";
@@ -15,6 +14,7 @@ import {
   ArticleSectionTwoColumns,
   ArticleSectionWrapper,
 } from "@/components/layout/article";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import { Country, getCountryName } from "@/utils/countries";
@@ -44,7 +44,7 @@ const CurrentCountryPart = ({
 }) => {
   const t = useTranslations();
   const tCountries = useTranslations("countries");
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const [expandedDonors, setExpandedDonors] = useState<string[]>([]);
   const onToggleExpanded = (state: string) => {
     setExpandedDonors((prev) =>
@@ -90,7 +90,7 @@ const CurrentCountryPart = ({
                 : // @ts-expect-error - we know that state is defined because it is used in the bucket
                   t(`state.${country.id}.${largestDonationSum[1].state!}`),
               highestSum: formatCountryCurrency(
-                locale,
+                browserBasedLocale,
                 largestDonationSum[1].sum,
                 country,
               ),
@@ -148,7 +148,7 @@ const OtherCountryPart = ({
 }) => {
   const t = useTranslations();
   const tCountries = useTranslations("countries");
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const [expandedCountries, setExpandedCountries] = useState<string[]>([]);
   const onToggleExpanded = (state: string) => {
     setExpandedCountries((prev) =>
@@ -194,7 +194,7 @@ const OtherCountryPart = ({
                 ][AddressField.Country]!}`,
               ),
               highestSum: formatCountryCurrency(
-                locale,
+                browserBasedLocale,
                 largesOtherDonationSum[1].sum,
                 country,
               ),
@@ -312,7 +312,7 @@ const DonationOrigin = ({
 }) => {
   const t = useTranslations();
   const tCountries = useTranslations("countries");
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const { sum, sums } = getOriginDonations(country, donations, parties, years);
 
   const isEu = country.id === Country.europeanunion;
@@ -374,8 +374,16 @@ const DonationOrigin = ({
                     ? formatYearsRange(years)
                     : (years.at(0) as string),
                 country: getCountryName(country, tCountries),
-                sumCountry: formatCountryCurrency(locale, sumCountry, country),
-                sumOthers: formatCountryCurrency(locale, sumOthers, country),
+                sumCountry: formatCountryCurrency(
+                  browserBasedLocale,
+                  sumCountry,
+                  country,
+                ),
+                sumOthers: formatCountryCurrency(
+                  browserBasedLocale,
+                  sumOthers,
+                  country,
+                ),
               })}
             </p>
           </ArticleSectionColumn>

--- a/src/components/donations/noninteractable-ranking-item.tsx
+++ b/src/components/donations/noninteractable-ranking-item.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 
 import type { CountryConfig } from "@/types/country-config";
-import type { ConstLocale } from "@/utils/locales";
+import type { BrowserBasedLocale } from "@/utils/locales";
 
 import { RankBadge } from "@/components/donations/ranking-item";
 import { PercentageHint } from "@/components/percentage-hint";
@@ -18,7 +18,7 @@ export const NonInteractableRankingItem = ({
   amount: number;
   rank: number;
   sum: number;
-  locale: ConstLocale;
+  locale: BrowserBasedLocale;
   country: CountryConfig;
 }>) => {
   return (
@@ -34,7 +34,7 @@ export const NonInteractableRankingItem = ({
         <span className="mr-1">
           {formatCountryCurrency(locale, amount, country)}
         </span>
-        <PercentageHint locale={locale} percentage={amount / sum} />
+        <PercentageHint browserBasedLocale={locale} percentage={amount / sum} />
       </div>
     </section>
   );

--- a/src/components/donations/ranking-item-line.tsx
+++ b/src/components/donations/ranking-item-line.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 
 import type { CountryConfig } from "@/types/country-config";
-import type { ConstLocale } from "@/utils/locales";
+import type { BrowserBasedLocale } from "@/utils/locales";
 
 import { cn } from "@/lib/utils";
 import { donationYear } from "@/utils/date";
@@ -21,7 +21,7 @@ export const RankingItemLine = ({
   label: string;
   date: string;
   amount: number;
-  locale: ConstLocale;
+  locale: BrowserBasedLocale;
   country: CountryConfig;
   year: string;
   className?: string;

--- a/src/components/donations/ranking-item.tsx
+++ b/src/components/donations/ranking-item.tsx
@@ -1,11 +1,11 @@
 import type { PropsWithChildren, ReactNode } from "react";
 
 import { ChevronRight } from "lucide-react";
-import { useLocale } from "next-intl";
 
 import type { CountryConfig } from "@/types/country-config";
 
 import { PercentageHint } from "@/components/percentage-hint";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { formatCountryCurrency } from "@/utils/formatter";
 
 const colorClasses: Record<number, string> = {
@@ -50,7 +50,7 @@ export const CurrencyRankingItem = ({
   onToggleExpanded: (expanded: boolean) => void;
   openAction?: ReactNode;
 }>) => {
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   return (
     <RankingItem
@@ -64,9 +64,12 @@ export const CurrencyRankingItem = ({
       right={
         <>
           <span className="lg:mr-1">
-            {formatCountryCurrency(locale, amount, country)}
+            {formatCountryCurrency(browserBasedLocale, amount, country)}
           </span>
-          <PercentageHint locale={locale} percentage={amount / sum} />
+          <PercentageHint
+            browserBasedLocale={browserBasedLocale}
+            percentage={amount / sum}
+          />
         </>
       }
     >

--- a/src/components/donors/donor-donations-detail.tsx
+++ b/src/components/donors/donor-donations-detail.tsx
@@ -8,6 +8,7 @@ import type { Donation, ReceiverId } from "@/utils/types";
 import { RankingItemLine } from "@/components/donations/ranking-item-line";
 import { PartyDot } from "@/components/parties/party-dot";
 import { PartyLink } from "@/components/parties/party-link";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { donationYear } from "@/utils/date";
 import { DonationField } from "@/utils/types";
 
@@ -25,6 +26,7 @@ export const DonorDonationsDetail = ({
   onVisibleChanged?: () => void;
 }) => {
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   useEffect(() => {
     onVisibleChanged?.();
@@ -40,7 +42,7 @@ export const DonorDonationsDetail = ({
       key={donation[DonationField.Id]}
       date={donation[DonationField.Date]}
       amount={donation[DonationField.Amount]}
-      locale={locale}
+      locale={browserBasedLocale}
       country={country}
     >
       <PartyLink party={party} country={country} locale={locale}>

--- a/src/components/donors/donors-hero.tsx
+++ b/src/components/donors/donors-hero.tsx
@@ -1,12 +1,14 @@
 "use client";
+import { useLocale } from "next-intl";
 import Link from "next/link";
 
 import type { CountryConfig } from "@/types/country-config";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
-import type { ConstLocale } from "@/utils/locales";
+import type { BrowserBasedLocale, ConstLocale } from "@/utils/locales";
 
 import { DynamicStackedPartyDonations } from "@/components/charts/dynamic-stacked-party-line";
 import { DonorName } from "@/components/donors/donor-name";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useHash } from "@/hooks/use-hash";
 import { formatCountryCurrency } from "@/utils/formatter";
 
@@ -16,9 +18,11 @@ export const BigDonorPill = ({
   country,
   donor,
   locale,
+  browserBasedLocale,
 }: {
   donor: Omit<BigDonor, "id"> & { id?: string };
   locale: ConstLocale;
+  browserBasedLocale: BrowserBasedLocale;
   country: CountryConfig;
 }) => {
   const { hash } = useHash(donor.name);
@@ -36,7 +40,6 @@ export const BigDonorPill = ({
           <DynamicStackedPartyDonations
             country={country}
             years={country.years}
-            locale={locale}
             partyYearsSums={donor.partyYearSums}
             direction={"vertical"}
           />
@@ -46,7 +49,7 @@ export const BigDonorPill = ({
             <DonorName donor={donor.name} />
           </div>
           <div className="tabular-nums">
-            {formatCountryCurrency(locale, donor.sum, country)}
+            {formatCountryCurrency(browserBasedLocale, donor.sum, country)}
           </div>
         </div>
       </Link>
@@ -56,21 +59,23 @@ export const BigDonorPill = ({
 
 export const DonorsHero = ({
   country,
-  locale,
   biggestDonors,
 }: {
-  locale: ConstLocale;
   country: CountryConfig;
   biggestDonors: BigDonor[];
 }) => {
+  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
+
   return (
     <ul className="flex flex-wrap pt-4">
       {biggestDonors.slice(0, TOP_DONORS_TO_SHOW).map((bigDonor) => (
         <BigDonorPill
+          locale={locale}
+          browserBasedLocale={browserBasedLocale}
           donor={bigDonor}
           country={country}
           key={bigDonor.id}
-          locale={locale}
         />
       ))}
     </ul>

--- a/src/components/donors/related-donor-chip.tsx
+++ b/src/components/donors/related-donor-chip.tsx
@@ -6,10 +6,10 @@ import { BriefcaseBusiness, Building2, Landmark } from "lucide-react";
 
 import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
-import type { ConstLocale } from "@/utils/locales";
 
 import { DonorLink } from "@/components/donors/donor-link";
 import { Family } from "@/components/icons/Family";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { formatCompactCountryCurrency } from "@/utils/formatter";
 import { sumPartySums } from "@/utils/math";
 import { RelationKind } from "@/utils/types";
@@ -24,16 +24,15 @@ const kindIcons: Record<RelationKind, JSX.Element> = {
 export const RelatedDonorChip = ({
   name,
   kind,
-  locale,
   country,
   sums,
 }: {
   name: string;
   kind: RelationKind;
-  locale: ConstLocale;
   country: CountryConfig;
   sums?: PartyYearsSums;
 }) => {
+  const browserBasedLocale = useBrowserBasedLocale();
   const sum = sumPartySums(sums ?? {});
 
   return (
@@ -48,7 +47,7 @@ export const RelatedDonorChip = ({
       <span>{name}</span>
       {sums ? (
         <span className="bg-primary/10 ml-2 rounded-full px-1.5 py-0.5 text-xs">
-          {formatCompactCountryCurrency(locale, sum, country)}
+          {formatCompactCountryCurrency(browserBasedLocale, sum, country)}
         </span>
       ) : null}
     </DonorLink>

--- a/src/components/donors/years-donor-histogram-text.tsx
+++ b/src/components/donors/years-donor-histogram-text.tsx
@@ -1,14 +1,13 @@
 "use client";
-import { useLocale } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
-import type { ConstLocale } from "@/utils/locales";
 import type { Donation } from "@/utils/types";
 
 import { RankingItem } from "@/components/donations/ranking-item";
 import { DonorLink } from "@/components/donors/donor-link";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { useBreakpoint } from "@/hooks/use-media-query";
 import { useVirtual } from "@/hooks/use-virtual";
@@ -27,15 +26,14 @@ type DonorHistogram = Record<number, Record<string, number>>;
 const HistogramItemDetailLine = ({
   country,
   amount,
-  locale,
   donor,
 }: {
-  locale: ConstLocale;
   country: CountryConfig;
   amount: number;
   donor: string;
 }) => {
-  const fmtAmount = formatCountryCurrency(locale, amount, country);
+  const browserBasedLocale = useBrowserBasedLocale();
+  const fmtAmount = formatCountryCurrency(browserBasedLocale, amount, country);
 
   return (
     <div className="mb-2 grow flex-wrap items-center justify-between space-y-2 overflow-hidden border-t border-gray-950/10 px-1 py-1.5 leading-none first:border-t-0 odd:bg-white/5 sm:mb-0 sm:flex sm:flex-nowrap sm:space-y-0 dark:odd:bg-slate-900/5">
@@ -52,11 +50,9 @@ const HistogramItemDetailLine = ({
 export const HistogramItemDetail = ({
   country,
   sums,
-  locale,
 }: {
   country: CountryConfig;
   sums: { donor: string; sum: number }[];
-  locale: ConstLocale;
 }) => {
   const t = useTranslations();
   const parentRef = useRef<HTMLDivElement>(null);
@@ -101,7 +97,6 @@ export const HistogramItemDetail = ({
               }}
             >
               <HistogramItemDetailLine
-                locale={locale}
                 country={country}
                 donor={donor}
                 amount={sum}
@@ -124,7 +119,7 @@ const DonorHistogramTextText = ({
   years: string[];
 }) => {
   const t = useTranslations();
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const sortedBuckets = Object.entries(histogram)
     .map(([receiversCount, donors]) => ({
@@ -164,8 +159,8 @@ const DonorHistogramTextText = ({
           years: formatYearsRange(years),
           max: maxBucket?.receiversCount ?? 0,
           donors: maxBucket?.donorCount ?? 0,
-          median: formatOneFractionNumber(locale, median),
-          mean: formatOneFractionNumber(locale, mean),
+          median: formatOneFractionNumber(browserBasedLocale, median),
+          mean: formatOneFractionNumber(browserBasedLocale, mean),
         })}
       </p>
       <p className="mb-6"></p>
@@ -173,7 +168,7 @@ const DonorHistogramTextText = ({
         <p className="mb-6">
           {t("donors.histogram.p2", {
             percentage: formatPercentFormat(
-              locale,
+              browserBasedLocale,
               justOne.donorCount / donorsCount,
             ),
             singlePartyDonors: justOne.donorCount,
@@ -188,10 +183,8 @@ const DonorHistogramTextText = ({
 const DonorHistogramTextList = ({
   countDonorSums,
   country,
-  locale,
 }: {
   country: CountryConfig;
-  locale: ConstLocale;
   countDonorSums: {
     receiversCount: string;
     donorSums: {
@@ -223,11 +216,7 @@ const DonorHistogramTextList = ({
               expanded={expandedBuckets.includes(receiversCount)}
               onToggleExpanded={() => onToggleExpanded(receiversCount)}
               detail={
-                <HistogramItemDetail
-                  locale={locale}
-                  country={country}
-                  sums={donorSums}
-                />
+                <HistogramItemDetail country={country} sums={donorSums} />
               }
             >
               {t("donors.histogram.item", {
@@ -247,13 +236,11 @@ const LoadedYearsDonorHistogramText = ({
   country,
   parties,
   donations,
-  locale,
 }: {
   years: string[];
   country: CountryConfig;
   parties: Party[];
   donations: Donation[];
-  locale: ConstLocale;
 }) => {
   const yearsSet = new Set<string>(years);
   const partiesSet = new Set<Party>(parties);
@@ -324,7 +311,6 @@ const LoadedYearsDonorHistogramText = ({
       />
       <DonorHistogramTextList
         country={country}
-        locale={locale}
         countDonorSums={countDonorSums}
       />
     </>
@@ -342,11 +328,8 @@ export const YearsDonorHistogramText = ({
   parties: Party[];
   donations: Donation[];
 }) => {
-  const locale = useLocale();
-
   return (
     <LoadedYearsDonorHistogramText
-      locale={locale}
       donations={donations}
       country={country}
       parties={parties}

--- a/src/components/donors/years-donor-page-text.tsx
+++ b/src/components/donors/years-donor-page-text.tsx
@@ -8,6 +8,7 @@ import type { Donation } from "@/utils/types";
 import { DonorLink } from "@/components/donors/donor-link";
 import { FormatAnd } from "@/components/formatter";
 import { Translation } from "@/components/translation";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import { donationYear } from "@/utils/date";
@@ -33,6 +34,7 @@ export const YearsDonorPageText = ({
 }) => {
   const t = useTranslations();
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const biggestDonor: { donor: string; amount: number } = {
     donor: "",
@@ -133,7 +135,7 @@ export const YearsDonorPageText = ({
     <>
       <p className="mb-6">
         {t("donors.detail.unique_donors", {
-          years: formatAnd(locale, years),
+          years: formatAnd(browserBasedLocale, years),
           count: Object.keys(donorDonations).length,
         })}
       </p>
@@ -151,7 +153,12 @@ export const YearsDonorPageText = ({
                   items={topDonors.map((d, i) => (
                     <span key={i}>
                       <DonorLink country={country} donor={d.donor} /> (
-                      {formatCountryCurrency(locale, d.amount, country)})
+                      {formatCountryCurrency(
+                        browserBasedLocale,
+                        d.amount,
+                        country,
+                      )}
+                      )
                     </span>
                   ))}
                 />
@@ -167,7 +174,7 @@ export const YearsDonorPageText = ({
             text={t.raw("donors.detail.biggest_donor")}
             variables={{
               amount: formatCountryCurrency(
-                locale,
+                browserBasedLocale,
                 biggestDonor.amount,
                 country,
               ),
@@ -183,7 +190,7 @@ export const YearsDonorPageText = ({
             variables={{
               count: mostDonationsDonor.count,
               sum: formatCountryCurrency(
-                locale,
+                browserBasedLocale,
                 mostDonationsDonor.sum,
                 country,
               ),
@@ -202,7 +209,7 @@ export const YearsDonorPageText = ({
             variables={{
               count: mostUniquePartiesDonor.count,
               sum: formatCountryCurrency(
-                locale,
+                browserBasedLocale,
                 mostUniquePartiesDonor.sum,
                 country,
               ),

--- a/src/components/layout/country-footer.tsx
+++ b/src/components/layout/country-footer.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import type { CountryConfig } from "@/types/country-config";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { formatDate } from "@/utils/formatter";
 import { getBuild } from "@/utils/loader/build";
@@ -13,6 +14,7 @@ import { PageLogo } from "./page-logo";
 export const CountryFooter = ({ country }: { country: CountryConfig }) => {
   const t = useTranslations();
   const locale = useLocale();
+  const browserLocale = useBrowserBasedLocale();
 
   return (
     <section className="container mx-auto shrink-0 px-4 text-gray-600 dark:text-gray-400">
@@ -28,9 +30,9 @@ export const CountryFooter = ({ country }: { country: CountryConfig }) => {
           </Link>
         </div>
 
-        <div className="px-2 text-sm sm:p-2">
+        <div className="px-2 text-sm sm:p-2" suppressHydrationWarning>
           {t("footer.build", {
-            date: formatDate(locale, new Date(getBuild(country.id).t)),
+            date: formatDate(browserLocale, new Date(getBuild(country.id).t)),
           })}
         </div>
 

--- a/src/components/loading/loading-top-year-donations-item-detail.tsx
+++ b/src/components/loading/loading-top-year-donations-item-detail.tsx
@@ -10,6 +10,7 @@ import { DonorLink } from "@/components/donors/donor-link";
 import { PartyDot } from "@/components/parties/party-dot";
 import { PartyLink } from "@/components/parties/party-link";
 import { useDonationsByYears } from "@/hooks/use-api";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { useBreakpoint } from "@/hooks/use-media-query";
 import { useVirtual } from "@/hooks/use-virtual";
@@ -109,6 +110,7 @@ export const TopDonationsItemDetail = ({
   const t = useTranslations();
   const tCommon = useTranslations("common");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const parentRef = useRef<HTMLDivElement>(null);
   const isSm = useBreakpoint("sm");
 
@@ -158,7 +160,7 @@ export const TopDonationsItemDetail = ({
                 label={getDonationDonorName(donation, tCommon)}
                 date={donation[DonationField.Date]}
                 amount={donation[DonationField.Amount]}
-                locale={locale}
+                locale={browserBasedLocale}
                 country={country}
               >
                 <div className="flex items-center space-x-1 truncate">

--- a/src/components/loading/loading-top-year-donations-item.tsx
+++ b/src/components/loading/loading-top-year-donations-item.tsx
@@ -1,7 +1,7 @@
 import { ArrowRight } from "lucide-react";
 
 import type { CountryConfig } from "@/types/country-config";
-import type { ConstLocale } from "@/utils/locales";
+import type { BrowserBasedLocale, ConstLocale } from "@/utils/locales";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { NonInteractableRankingItem } from "@/components/donations/noninteractable-ranking-item";
@@ -23,7 +23,7 @@ export const ReadonlyTopYearDonationsItem = ({
   amount: number;
   rank: number;
   sum: number;
-  locale: ConstLocale;
+  locale: BrowserBasedLocale;
   country: CountryConfig;
 }) => {
   return (

--- a/src/components/loading/loading-year-bars-page-text.tsx
+++ b/src/components/loading/loading-year-bars-page-text.tsx
@@ -8,6 +8,7 @@ import type { Donation, ReceiverId } from "@/utils/types";
 import { FormatAnd } from "@/components/formatter";
 import { TextPartyLink } from "@/components/parties/text-party-link";
 import { Translation } from "@/components/translation";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import { donationYear } from "@/utils/date";
@@ -27,6 +28,7 @@ export const YearBarsPageText = ({
 }) => {
   const t = useTranslations();
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const yearsSet = new Set<string>(years);
   const partiesSet = new Set<string>(parties.map((p) => p[PartyField.Id]));
@@ -113,11 +115,11 @@ export const YearBarsPageText = ({
             text={t.raw("per_month.highest_sum")}
             variables={{
               month: formatMonthYear(
-                locale,
+                browserBasedLocale,
                 new Date(monthWithHighestDonationSum.date),
               ),
               sum: formatCountryCurrency(
-                locale,
+                browserBasedLocale,
                 monthWithHighestDonationSum.sum,
                 country,
               ),
@@ -155,7 +157,7 @@ export const YearBarsPageText = ({
             text={t.raw("per_month.month_most_donations")}
             variables={{
               month: formatMonthYear(
-                locale,
+                browserBasedLocale,
                 new Date(monthWithMostDonations.date),
               ),
               count: monthWithMostDonations.count,

--- a/src/components/loading/loading-year-timeline-year-text.tsx
+++ b/src/components/loading/loading-year-timeline-year-text.tsx
@@ -1,10 +1,10 @@
 "use client";
-import { useLocale } from "next-intl";
 
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { PartyField } from "@/types/party";
 import { donationYear } from "@/utils/date";
 import { formatCountryCurrency, formatPercentFormat } from "@/utils/formatter";
@@ -21,7 +21,7 @@ export const YearTimelineYearText = ({
   years: string[];
   donations: Donation[];
 }) => {
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const partiesSet = new Set<string>(parties.map((p) => p[PartyField.Id]));
 
@@ -54,13 +54,15 @@ export const YearTimelineYearText = ({
         >
           <span>{year}</span>
           <span className="tabular-nums">
-            <span>{formatCountryCurrency(locale, yearSum, country)}</span>{" "}
+            <span>
+              {formatCountryCurrency(browserBasedLocale, yearSum, country)}
+            </span>{" "}
             <span
               className={
                 "hidden w-14 text-right text-gray-500 lg:inline-block dark:text-gray-400"
               }
             >
-              ({formatPercentFormat(locale, yearSum / total)})
+              ({formatPercentFormat(browserBasedLocale, yearSum / total)})
             </span>
           </span>
         </li>

--- a/src/components/parties/part-donor-type-text.tsx
+++ b/src/components/parties/part-donor-type-text.tsx
@@ -1,12 +1,11 @@
 "use client";
-import { useLocale } from "next-intl";
-
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation } from "@/utils/types";
 
 import { RankBadge } from "@/components/donations/ranking-item";
 import { PercentageHint } from "@/components/percentage-hint";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import { formatCountryCurrency } from "@/utils/formatter";
@@ -22,7 +21,7 @@ export const LoadingPartyDonorTypeText = ({
   donations: Donation[];
 }) => {
   const t = useTranslations();
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const sumByType: Partial<Record<DonorType, { sum: number; count: number }>> =
     {};
@@ -70,10 +69,14 @@ export const LoadingPartyDonorTypeText = ({
               </div>
               <div className="ml-2 flex tabular-nums">
                 <span className="lg:mr-1">
-                  {formatCountryCurrency(locale, stats.sum, country)}
+                  {formatCountryCurrency(
+                    browserBasedLocale,
+                    stats.sum,
+                    country,
+                  )}
                 </span>
                 <PercentageHint
-                  locale={locale}
+                  browserBasedLocale={browserBasedLocale}
                   percentage={stats.sum / totalSum}
                 />
               </div>

--- a/src/components/parties/parties-hero.tsx
+++ b/src/components/parties/parties-hero.tsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 import type { CountryConfig } from "@/types/country-config";
 import type { ConstLocale } from "@/utils/locales";
 
+import { FormattedCountryCurrency } from "@/components/browser-based-formatter";
 import { PartyField, type Party } from "@/types/party";
 import { partyColor } from "@/utils/color";
-import { formatCountryCurrency } from "@/utils/formatter";
 
 const VISIBLE_PARTIES = 4;
 
@@ -41,7 +41,10 @@ const PartyLinkPill = ({
         <div className="overflow-hidden pl-2 text-sm">
           <div className="truncate font-bold">{party[PartyField.Short]}</div>
           <div className="tabular-nums">
-            {formatCountryCurrency(locale, party[PartyField.Sum], country)}
+            <FormattedCountryCurrency
+              country={country}
+              value={party[PartyField.Sum]}
+            />
           </div>
         </div>
       </Link>

--- a/src/components/parties/party-comparison.tsx
+++ b/src/components/parties/party-comparison.tsx
@@ -5,7 +5,6 @@ import type { ReactNode } from "react";
 
 import { useQueries } from "@tanstack/react-query";
 import { Trophy } from "lucide-react";
-import { useLocale } from "next-intl";
 import { parseAsArrayOf, parseAsString, useQueryState } from "nuqs";
 import { useMemo } from "react";
 
@@ -21,6 +20,7 @@ import Loading from "@/components/loading/loading";
 import { PartyDot } from "@/components/parties/party-dot";
 import { Button } from "@/components/ui/button";
 import { YearRangeSelector } from "@/components/years/year-range-selector";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { donationDocumentToDonations } from "@/lib/api/donations-document";
 import { PartyField, type Party } from "@/types/party";
@@ -296,7 +296,7 @@ export const PartyComparison = ({
   const t = useTranslations();
   const tCompareParties = useTranslations("compare_parties");
   const tData = useTranslations("data");
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const [partiesParam, setPartiesParam] = useQueryState(
     "parties",
     parseAsArrayOf(parseAsString).withDefault([]),
@@ -412,22 +412,25 @@ export const PartyComparison = ({
   const overviewRows: ComparisonRow[] = [
     {
       label: tCompareParties("stats.sum"),
-      values: (s) => formatCountryCurrency(locale, s.totalSum, countryConfig),
+      values: (s) =>
+        formatCountryCurrency(browserBasedLocale, s.totalSum, countryConfig),
       winner: winners.totalSum,
     },
     {
       label: tCompareParties("stats.count"),
-      values: (s) => formatNumber(locale, s.count),
+      values: (s) => formatNumber(browserBasedLocale, s.count),
       winner: winners.count,
     },
     {
       label: tCompareParties("stats.avg"),
-      values: (s) => formatCountryCurrency(locale, s.average, countryConfig),
+      values: (s) =>
+        formatCountryCurrency(browserBasedLocale, s.average, countryConfig),
       winner: winners.average,
     },
     {
       label: tCompareParties("stats.median"),
-      values: (s) => formatCountryCurrency(locale, s.median, countryConfig),
+      values: (s) =>
+        formatCountryCurrency(browserBasedLocale, s.median, countryConfig),
       winner: winners.median,
     },
   ];
@@ -448,7 +451,7 @@ export const PartyComparison = ({
           <TwoLineCell
             primary={s.mostActiveYear.year}
             secondary={formatCountryCurrency(
-              locale,
+              browserBasedLocale,
               s.mostActiveYear.sum,
               countryConfig,
             )}
@@ -465,7 +468,10 @@ export const PartyComparison = ({
           <TwoLineCell
             primary={s.yearWithMostDonations.year}
             secondary={tCompareParties("n_donations", {
-              count: formatNumber(locale, s.yearWithMostDonations.count),
+              count: formatNumber(
+                browserBasedLocale,
+                s.yearWithMostDonations.count,
+              ),
             })}
           />
         ) : (
@@ -478,7 +484,7 @@ export const PartyComparison = ({
   const donorRows: ComparisonRow[] = [
     {
       label: tCompareParties("stats.unique_donors"),
-      values: (s) => formatNumber(locale, s.uniqueDonors.size),
+      values: (s) => formatNumber(browserBasedLocale, s.uniqueDonors.size),
       winner: winners.uniqueDonors,
     },
     {
@@ -490,7 +496,7 @@ export const PartyComparison = ({
               <DonorLink country={countryConfig} donor={s.topDonor.name} />
             }
             secondary={formatCountryCurrency(
-              locale,
+              browserBasedLocale,
               s.topDonor.sum,
               countryConfig,
             )}
@@ -512,7 +518,10 @@ export const PartyComparison = ({
               />
             }
             secondary={tCompareParties("n_donations", {
-              count: formatNumber(locale, s.mostFrequentDonor.count),
+              count: formatNumber(
+                browserBasedLocale,
+                s.mostFrequentDonor.count,
+              ),
             })}
           />
         ) : (
@@ -529,7 +538,7 @@ export const PartyComparison = ({
         s.largestDonation ? (
           <TwoLineCell
             primary={formatCountryCurrency(
-              locale,
+              browserBasedLocale,
               s.largestDonation[DonationField.Amount],
               countryConfig,
             )}
@@ -719,7 +728,7 @@ export const PartyComparison = ({
                                     </div>
                                     <div className="text-muted-foreground text-xs tabular-nums">
                                       {formatCountryCurrency(
-                                        locale,
+                                        browserBasedLocale,
                                         donor.sum,
                                         countryConfig,
                                       )}
@@ -779,7 +788,7 @@ export const PartyComparison = ({
                                       </div>
                                       <div className="text-muted-foreground text-xs font-medium tabular-nums">
                                         {formatCountryCurrency(
-                                          locale,
+                                          browserBasedLocale,
                                           donor.sum,
                                           countryConfig,
                                         )}
@@ -822,10 +831,10 @@ export const PartyComparison = ({
                         <TwoLineCell
                           primary={top.label}
                           secondary={`${formatCountryCurrency(
-                            locale,
+                            browserBasedLocale,
                             top.sum,
                             countryConfig,
-                          )} · ${formatPercentFormat(locale, top.percentage)}`}
+                          )} · ${formatPercentFormat(browserBasedLocale, top.percentage)}`}
                         />
                       ) : (
                         NO_DATA_TEXT
@@ -895,11 +904,11 @@ export const PartyComparison = ({
                                       {entry ? (
                                         <TwoLineCell
                                           primary={formatPercentFormat(
-                                            locale,
+                                            browserBasedLocale,
                                             entry.percentage,
                                           )}
                                           secondary={formatCountryCurrency(
-                                            locale,
+                                            browserBasedLocale,
                                             entry.sum,
                                             countryConfig,
                                           )}
@@ -950,11 +959,11 @@ export const PartyComparison = ({
                                         {entry ? (
                                           <TwoLineCell
                                             primary={formatPercentFormat(
-                                              locale,
+                                              browserBasedLocale,
                                               entry.percentage,
                                             )}
                                             secondary={formatCountryCurrency(
-                                              locale,
+                                              browserBasedLocale,
                                               entry.sum,
                                               countryConfig,
                                             )}
@@ -998,7 +1007,10 @@ export const PartyComparison = ({
               <div className="mt-6">
                 <h3 className="mb-3 text-lg font-semibold">
                   {tCompareParties("overlapping.title", {
-                    count: formatNumber(locale, overlappingDonors.length),
+                    count: formatNumber(
+                      browserBasedLocale,
+                      overlappingDonors.length,
+                    ),
                   })}
                 </h3>
                 <p className="text-muted-foreground mb-4 text-sm">
@@ -1043,14 +1055,14 @@ export const PartyComparison = ({
                                 </div>
                                 <div className="text-muted-foreground text-xs tabular-nums">
                                   {formatCompactCountryCurrency(
-                                    locale,
+                                    browserBasedLocale,
                                     donor.totalSum,
                                     countryConfig,
                                   )}
                                   {" · "}
                                   {tCompareParties("n_donations", {
                                     count: formatNumber(
-                                      locale,
+                                      browserBasedLocale,
                                       donor.totalSum > 0
                                         ? Object.values(donor.perParty).reduce(
                                             (acc, d) => acc + d.count,
@@ -1072,7 +1084,7 @@ export const PartyComparison = ({
                                     {data ? (
                                       <TwoLineCell
                                         primary={formatCountryCurrency(
-                                          locale,
+                                          browserBasedLocale,
                                           data.sum,
                                           countryConfig,
                                         )}
@@ -1080,7 +1092,7 @@ export const PartyComparison = ({
                                           "n_donations",
                                           {
                                             count: formatNumber(
-                                              locale,
+                                              browserBasedLocale,
                                               data.count,
                                             ),
                                           },
@@ -1113,14 +1125,14 @@ export const PartyComparison = ({
                           </h4>
                           <div className="text-muted-foreground mt-0.5 text-xs font-medium tabular-nums">
                             {formatCompactCountryCurrency(
-                              locale,
+                              browserBasedLocale,
                               donor.totalSum,
                               countryConfig,
                             )}
                             {" · "}
                             {tCompareParties("n_donations", {
                               count: formatNumber(
-                                locale,
+                                browserBasedLocale,
                                 donor.totalSum > 0
                                   ? Object.values(donor.perParty).reduce(
                                       (acc, d) => acc + d.count,
@@ -1157,7 +1169,7 @@ export const PartyComparison = ({
                                     {data ? (
                                       <TwoLineCell
                                         primary={formatCountryCurrency(
-                                          locale,
+                                          browserBasedLocale,
                                           data.sum,
                                           countryConfig,
                                         )}
@@ -1165,7 +1177,7 @@ export const PartyComparison = ({
                                           "n_donations",
                                           {
                                             count: formatNumber(
-                                              locale,
+                                              browserBasedLocale,
                                               data.count,
                                             ),
                                           },
@@ -1190,7 +1202,7 @@ export const PartyComparison = ({
                   <p className="text-muted-foreground px-4 py-2 text-sm">
                     {tCompareParties("overlapping.more", {
                       count: formatNumber(
-                        locale,
+                        browserBasedLocale,
                         overlappingDonors.length - OVERLAP_MAX,
                       ),
                     })}

--- a/src/components/parties/party-donor-page-text.tsx
+++ b/src/components/parties/party-donor-page-text.tsx
@@ -12,6 +12,7 @@ import { FormatAnd } from "@/components/formatter";
 import { ArticleSectionTitle } from "@/components/layout/article";
 import { FaqSchema } from "@/components/schema";
 import { Translation } from "@/components/translation";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import { isNotNullandNotUndefined } from "@/utils/array";
@@ -38,6 +39,7 @@ export const PartyDonorPageText = ({
 }) => {
   const t = useTranslations();
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   let sum = 0;
   const donations = data;
@@ -124,14 +126,14 @@ export const PartyDonorPageText = ({
       question: t("party.qa.sum.q", { party: party[PartyField.Short] }),
       answer: t("party.qa.sum.a", {
         party: party[PartyField.Short],
-        sum: formatCountryCurrency(locale, sum, country),
+        sum: formatCountryCurrency(browserBasedLocale, sum, country),
         count: partyDonations.length,
         minYear: formatYear(
-          locale,
+          browserBasedLocale,
           new Date(firstDonation[DonationField.Date]),
         ),
         minSum: formatCompactCountryCurrency(
-          locale,
+          browserBasedLocale,
           country.minPublicDonationAmount,
           country,
         ),
@@ -142,10 +144,10 @@ export const PartyDonorPageText = ({
       answer: t("party.qa.top_donors.a", {
         party: party[PartyField.Short],
         donors: formatAnd(
-          locale,
+          browserBasedLocale,
           topDonors.map(
             (d) =>
-              `${d.name} (${formatCountryCurrency(locale, d.sum, country)})`,
+              `${d.name} (${formatCountryCurrency(browserBasedLocale, d.sum, country)})`,
           ),
         ),
       }),
@@ -160,7 +162,7 @@ export const PartyDonorPageText = ({
                 items={topDonors.map((d, i) => (
                   <span key={i}>
                     <DonorLink country={country} donor={d.name} /> (
-                    {formatCountryCurrency(locale, d.sum, country)})
+                    {formatCountryCurrency(browserBasedLocale, d.sum, country)})
                   </span>
                 ))}
               />
@@ -176,13 +178,13 @@ export const PartyDonorPageText = ({
           }),
           answer: t("party.qa.largest_singular.a", {
             amount: formatCountryCurrency(
-              locale,
+              browserBasedLocale,
               biggestSingularDonation[DonationField.Amount],
               country,
             ),
             donor: biggestSingularDonation[DonationField.DonorName],
             date: formatDate(
-              locale,
+              browserBasedLocale,
               new Date(biggestSingularDonation[DonationField.Date]),
             ),
           }),
@@ -191,7 +193,7 @@ export const PartyDonorPageText = ({
               text={t.raw("party.qa.largest_singular.a")}
               variables={{
                 amount: formatCountryCurrency(
-                  locale,
+                  browserBasedLocale,
                   biggestSingularDonation[DonationField.Amount],
                   country,
                 ),
@@ -202,7 +204,7 @@ export const PartyDonorPageText = ({
                   />
                 ),
                 date: formatDate(
-                  locale,
+                  browserBasedLocale,
                   new Date(biggestSingularDonation[DonationField.Date]),
                 ),
               }}
@@ -218,7 +220,11 @@ export const PartyDonorPageText = ({
           answer: t("party.qa.biggest_overall.a", {
             party: party[PartyField.Short],
             donor: biggestDonor.name,
-            sum: formatCountryCurrency(locale, biggestDonor.sum, country),
+            sum: formatCountryCurrency(
+              browserBasedLocale,
+              biggestDonor.sum,
+              country,
+            ),
           }),
 
           answerHTML: (
@@ -229,7 +235,11 @@ export const PartyDonorPageText = ({
                 donor: (
                   <DonorLink country={country} donor={biggestDonor.name} />
                 ),
-                sum: formatCountryCurrency(locale, biggestDonor.sum, country),
+                sum: formatCountryCurrency(
+                  browserBasedLocale,
+                  biggestDonor.sum,
+                  country,
+                ),
               }}
             />
           ),
@@ -245,7 +255,7 @@ export const PartyDonorPageText = ({
             donor: frequentDonor.name,
             count: frequentDonor.count,
             sum: formatCountryCurrency(
-              locale,
+              browserBasedLocale,
               donorDonations[frequentDonor.name],
               country,
             ),
@@ -260,7 +270,7 @@ export const PartyDonorPageText = ({
                 ),
                 count: frequentDonor.count,
                 sum: formatCountryCurrency(
-                  locale,
+                  browserBasedLocale,
                   donorDonations[frequentDonor.name],
                   country,
                 ),
@@ -283,11 +293,11 @@ export const PartyDonorPageText = ({
         {t("party.donors.summary", {
           party: party[PartyField.Short],
           minYear: formatYear(
-            locale,
+            browserBasedLocale,
             new Date(firstDonation[DonationField.Date]),
           ),
           minSum: formatCompactCountryCurrency(
-            locale,
+            browserBasedLocale,
             country.minPublicDonationAmount,
             country,
           ),

--- a/src/components/parties/party-timeline-text.tsx
+++ b/src/components/parties/party-timeline-text.tsx
@@ -1,10 +1,10 @@
 "use client";
-import { useLocale } from "next-intl";
 
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { Donation } from "@/utils/types";
 
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { PartyField } from "@/types/party";
 import { donationYear } from "@/utils/date";
@@ -21,7 +21,7 @@ export const PartyTimelineText = ({
   donations: Donation[];
 }) => {
   const t = useTranslations();
-  const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   let sum = 0;
   const perYearSums: Record<string, number> = {};
@@ -51,13 +51,15 @@ export const PartyTimelineText = ({
             >
               <span>{year}</span>
               <span className="tabular-nums">
-                <span>{formatCountryCurrency(locale, yearSum, country)}</span>{" "}
+                <span>
+                  {formatCountryCurrency(browserBasedLocale, yearSum, country)}
+                </span>{" "}
                 <span
                   className={
                     "hidden w-14 text-right text-gray-500 lg:inline-block dark:text-gray-400"
                   }
                 >
-                  ({formatPercentFormat(locale, yearSum / sum)})
+                  ({formatPercentFormat(browserBasedLocale, yearSum / sum)})
                 </span>
               </span>
             </li>

--- a/src/components/percentage-hint.tsx
+++ b/src/components/percentage-hint.tsx
@@ -1,17 +1,17 @@
-import type { ConstLocale } from "@/utils/locales";
+import type { BrowserBasedLocale } from "@/utils/locales";
 
 import { formatPercentFormat } from "@/utils/formatter";
 
 export const PercentageHint = ({
-  locale,
+  browserBasedLocale,
   percentage,
 }: {
-  locale: ConstLocale;
+  browserBasedLocale: BrowserBasedLocale;
   percentage: number;
 }) => {
   return (
     <span className="hidden w-14 text-right text-gray-500 tabular-nums lg:block dark:text-gray-400">
-      ({formatPercentFormat(locale, percentage)})
+      ({formatPercentFormat(browserBasedLocale, percentage)})
     </span>
   );
 };

--- a/src/components/table/donation-history-table.tsx
+++ b/src/components/table/donation-history-table.tsx
@@ -30,6 +30,7 @@ import { DonorLink } from "@/components/donors/donor-link";
 import { DonorName } from "@/components/donors/donor-name";
 import { PartyDot } from "@/components/parties/party-dot";
 import { PartyLink } from "@/components/parties/party-link";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { useMobile } from "@/hooks/use-media-query";
 import { useVirtual } from "@/hooks/use-virtual";
@@ -62,6 +63,7 @@ export const DonationHistoryTable = ({
   const tCommon = useTranslations("common");
   const tSearch = useTranslations("search");
   const locale = useLocale();
+  const browserBasedLocale = useBrowserBasedLocale();
   const partiesIdSet = useMemo(() => new Set(partiesIds), [partiesIds]);
   const [sorting, setSorting] = useState<SortingState>([
     { id: "date", desc: true },
@@ -120,7 +122,7 @@ export const DonationHistoryTable = ({
                       {historyEntry.date !==
                       donationYear({ [DonationField.Date]: historyEntry.date })
                         ? formatTwoDigitDate(
-                            locale,
+                            browserBasedLocale,
                             new Date(historyEntry.date),
                           )
                         : historyEntry.date}
@@ -159,7 +161,7 @@ export const DonationHistoryTable = ({
                   <div className="flex items-center justify-between">
                     <div className="shrink-0 text-sm tabular-nums">
                       {formatCountryCurrency(
-                        locale,
+                        browserBasedLocale,
                         historyEntry.amount,
                         country,
                       )}
@@ -198,7 +200,7 @@ export const DonationHistoryTable = ({
           if (date === donationYear({ [DonationField.Date]: date }))
             return date;
 
-          return formatTwoDigitDate(locale, new Date(date));
+          return formatTwoDigitDate(browserBasedLocale, new Date(date));
         },
       }),
       columnHelper.accessor("party", {
@@ -254,7 +256,8 @@ export const DonationHistoryTable = ({
         meta: {
           className: "justify-end tabular-nums",
         },
-        cell: (cell) => formatCountryCurrency(locale, cell.getValue(), country),
+        cell: (cell) =>
+          formatCountryCurrency(browserBasedLocale, cell.getValue(), country),
       }),
       hasFeature(country, Features.ExternalDonationIds)
         ? columnHelper.accessor("id", {

--- a/src/components/years/years-cards.tsx
+++ b/src/components/years/years-cards.tsx
@@ -5,8 +5,8 @@ import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
 import type { ConstLocale } from "@/utils/locales";
 
+import { FormattedCompactCountryCurrency } from "@/components/browser-based-formatter";
 import { DynamicStackedPartyDonations } from "@/components/charts/dynamic-stacked-party-line";
-import { formatCompactCountryCurrency } from "@/utils/formatter";
 
 const VISIBLE_PARTIES = 6;
 
@@ -32,13 +32,12 @@ const YearCard = ({
       >
         <div className="mt-1 flex w-full justify-between">
           <span className="font-semibold">{year}</span>
-          {formatCompactCountryCurrency(locale, sum, country)}
+          <FormattedCompactCountryCurrency value={sum} country={country} />
         </div>
         <div className="mt-1 h-1">
           <DynamicStackedPartyDonations
             country={country}
             years={[year]}
-            locale={locale}
             partyYearsSums={partyYearsSums}
           />
         </div>

--- a/src/components/years/years-header.tsx
+++ b/src/components/years/years-header.tsx
@@ -12,6 +12,7 @@ import type { ConstLocale } from "@/utils/locales";
 import { DynamicStackedPartyDonations } from "@/components/charts/dynamic-stacked-party-line";
 import { ReadonlyTopYearDonationsItem } from "@/components/loading/loading-top-year-donations-item";
 import { MetaCard } from "@/components/meta-card";
+import { useBrowserBasedLocale } from "@/hooks/use-browser-based-locale";
 import { useClientTranslations as useTranslations } from "@/hooks/use-client-translations";
 import { cn } from "@/lib/utils";
 import { getParties } from "@/utils/data/get-parties";
@@ -89,6 +90,7 @@ const HighscoreHeader = ({
   titleBeforeYears?: boolean;
 }) => {
   const t = useTranslations();
+  const browserBasedLocale = useBrowserBasedLocale();
 
   const { count, sum, sums, sumNumbers } = getPartiesSum(
     country,
@@ -118,12 +120,12 @@ const HighscoreHeader = ({
           {hasFeature(country, Features.Donors) ? (
             <MetaCard
               title={t("donation_count")}
-              value={formatNumber(locale, count)}
+              value={formatNumber(browserBasedLocale, count)}
             />
           ) : null}
           <MetaCard
             title={t("sum")}
-            value={formatCountryCurrency(locale, sum, country)}
+            value={formatCountryCurrency(browserBasedLocale, sum, country)}
           />
           {hasFeature(country, Features.Donors) &&
             showExtendedMeta &&
@@ -131,7 +133,7 @@ const HighscoreHeader = ({
               <MetaCard
                 title={t("average")}
                 value={formatCountryCurrency(
-                  locale,
+                  browserBasedLocale,
                   numbersAvg(sumNumbers, count),
                   country,
                 )}
@@ -144,7 +146,6 @@ const HighscoreHeader = ({
           <DynamicStackedPartyDonations
             country={country}
             years={years}
-            locale={locale}
             partyYearsSums={partyYearsSums}
           />
         </div>
@@ -158,7 +159,7 @@ const HighscoreHeader = ({
               partyId={party}
               amount={data.sum}
               sum={sum}
-              locale={locale}
+              locale={browserBasedLocale}
               country={country}
             />
           ))}

--- a/src/hooks/use-browser-based-locale.ts
+++ b/src/hooks/use-browser-based-locale.ts
@@ -1,0 +1,15 @@
+import "client-only";
+import { useContext } from "react";
+
+import { BrowserBasedLocaleContext } from "@/app/providers";
+
+export const useBrowserBasedLocale = () => {
+  const ctx = useContext(BrowserBasedLocaleContext);
+
+  if (!ctx)
+    throw new Error(
+      "useBrowserBasedLocale must be used within BrowserBasedLocaleProvider",
+    );
+
+  return ctx;
+};

--- a/src/hooks/use-scroll-to-hash.ts
+++ b/src/hooks/use-scroll-to-hash.ts
@@ -1,5 +1,4 @@
-"client-only";
-
+import "client-only";
 import { useEffect } from "react";
 
 /**

--- a/src/utils/brand.ts
+++ b/src/utils/brand.ts
@@ -1,0 +1,11 @@
+declare const tags: unique symbol;
+export type Brand<BaseType, BrandName extends string> = BaseType & {
+  [tags]: { [K in BrandName]: never };
+};
+
+/**
+ * Create a branded instance of the value
+ * @param value
+ * @example const newDonor = makeBrand<DonorUuid>("123e4567-e89b-12d3-a456-426614174000");
+ */
+export const makeBrand = <T>(value: unknown): T => value as T;

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -3,21 +3,25 @@ import type { CountryConfig } from "@/types/country-config";
 import { PartyField } from "@/types/party";
 
 import type { Currency } from "./countries";
-import type { ConstLocale } from "./locales";
+import type {
+  BrowserBasedLocale,
+  ImageLocale,
+  MetadataLocale,
+} from "./locales";
 import type { ReceiverId } from "./types";
 
 import { getParty } from "./countries";
 import { createIntlCache } from "./intl-cache";
 
 const currencyFormatter = createIntlCache(
-  (locale: ConstLocale, currency: "EUR" | "CHF") =>
+  (locale: BrowserBasedLocale, currency: "EUR" | "CHF") =>
     new Intl.NumberFormat(locale, {
       style: "currency",
       currency,
     }),
 );
 const currencyCompactFormatter = createIntlCache(
-  (locale: ConstLocale, currency: "EUR" | "CHF") =>
+  (locale: BrowserBasedLocale | ImageLocale, currency: "EUR" | "CHF") =>
     new Intl.NumberFormat(locale, {
       style: "currency",
       notation: "compact",
@@ -26,7 +30,7 @@ const currencyCompactFormatter = createIntlCache(
 );
 
 export const formatCountryCurrency = (
-  locale: ConstLocale,
+  locale: BrowserBasedLocale | ImageLocale | MetadataLocale,
   amount: number,
   country: CountryConfig,
 ) => {
@@ -34,7 +38,7 @@ export const formatCountryCurrency = (
 };
 
 export const formatCurrency = (
-  locale: ConstLocale,
+  locale: BrowserBasedLocale | ImageLocale | MetadataLocale,
   amount: number,
   currency: Currency,
 ) => {
@@ -42,7 +46,7 @@ export const formatCurrency = (
 };
 
 export const formatCompactCountryCurrency = (
-  locale: ConstLocale,
+  locale: BrowserBasedLocale | ImageLocale | MetadataLocale,
   amount: number,
   country: CountryConfig,
 ) => {
@@ -50,7 +54,7 @@ export const formatCompactCountryCurrency = (
 };
 
 export const formatCompactCurrency = (
-  locale: ConstLocale,
+  locale: BrowserBasedLocale | ImageLocale | MetadataLocale,
   amount: number,
   currency: Currency,
 ) => {
@@ -63,7 +67,10 @@ const dateFormatter = createIntlCache(
       dateStyle: "long",
     }),
 );
-export const formatDate = (locale: ConstLocale, date: Date | number) => {
+export const formatDate = (
+  locale: BrowserBasedLocale | ImageLocale,
+  date: Date | number,
+) => {
   return dateFormatter(locale).format(date);
 };
 
@@ -74,23 +81,26 @@ const yearFormatter = createIntlCache(
     }),
 );
 
-export const formatYear = (locale: ConstLocale, date: Date | number) => {
+export const formatYear = (locale: BrowserBasedLocale, date: Date | number) => {
   return yearFormatter(locale).format(date);
 };
 
 const monthYearFormatter = createIntlCache(
-  (locale: ConstLocale) =>
+  (locale: BrowserBasedLocale) =>
     new Intl.DateTimeFormat(locale, {
       month: "long",
       year: "numeric",
     }),
 );
-export const formatMonthYear = (locale: ConstLocale, date: Date | number) => {
+export const formatMonthYear = (
+  locale: BrowserBasedLocale,
+  date: Date | number,
+) => {
   return monthYearFormatter(locale).format(date);
 };
 
 const twoDigitDateFormatter = createIntlCache(
-  (locale: ConstLocale) =>
+  (locale: BrowserBasedLocale | ImageLocale) =>
     new Intl.DateTimeFormat(locale, {
       year: "2-digit",
       month: "2-digit",
@@ -98,20 +108,20 @@ const twoDigitDateFormatter = createIntlCache(
     }),
 );
 export const formatTwoDigitDate = (
-  locale: ConstLocale,
+  locale: BrowserBasedLocale | ImageLocale,
   date: Date | number,
 ) => {
   return twoDigitDateFormatter(locale).format(date);
 };
 
 const relativeDateFormatter = createIntlCache(
-  (locale: ConstLocale) =>
+  (locale: BrowserBasedLocale | ImageLocale) =>
     new Intl.RelativeTimeFormat(locale, {
       style: "short",
     }),
 );
 export const formatRelativeDate = (
-  locale: ConstLocale,
+  locale: BrowserBasedLocale | ImageLocale,
   diff: number,
   unit: Intl.RelativeTimeFormatUnit,
 ) => {
@@ -121,14 +131,17 @@ export const formatRelativeDate = (
 };
 
 const percentFormatter = createIntlCache(
-  (locale: ConstLocale) =>
+  (locale: BrowserBasedLocale | ImageLocale) =>
     new Intl.NumberFormat(locale, {
       style: "percent",
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     }),
 );
-export const formatPercentFormat = (locale: ConstLocale, value: number) => {
+export const formatPercentFormat = (
+  locale: BrowserBasedLocale | ImageLocale,
+  value: number,
+) => {
   return percentFormatter(locale).format(value);
 };
 
@@ -139,23 +152,29 @@ export const andFormatter = createIntlCache(
       type: "conjunction",
     }),
 );
-export const formatAnd = (locale: ConstLocale, values: string[]): string => {
+export const formatAnd = (
+  locale: BrowserBasedLocale | ImageLocale,
+  values: string[],
+): string => {
   return andFormatter(locale).format(values);
 };
 
 const numberFormatter = createIntlCache(
-  (locale: ConstLocale) => new Intl.NumberFormat(locale),
+  (locale: BrowserBasedLocale | ImageLocale) => new Intl.NumberFormat(locale),
 );
-export const formatNumber = (locale: ConstLocale, value: number): string => {
+export const formatNumber = (
+  locale: BrowserBasedLocale | ImageLocale,
+  value: number,
+): string => {
   return numberFormatter(locale).format(value);
 };
 
 const oneFractionNumberFormatter = createIntlCache(
-  (locale: ConstLocale) =>
+  (locale: BrowserBasedLocale | ImageLocale) =>
     new Intl.NumberFormat(locale, { maximumFractionDigits: 1 }),
 );
 export const formatOneFractionNumber = (
-  locale: ConstLocale,
+  locale: BrowserBasedLocale | ImageLocale,
   value: number,
 ): string => {
   return oneFractionNumberFormatter(locale).format(value);

--- a/src/utils/locales.ts
+++ b/src/utils/locales.ts
@@ -1,3 +1,5 @@
+import type { Brand } from "@/utils/brand";
+
 export const LOCALES = [
   "en",
   "de",
@@ -26,3 +28,12 @@ export const DEFAULT_LOCALE = "en";
 export const LOCALES_SET = new Set(CONST_LOCALES);
 
 export type ConstLocale = (typeof CONST_LOCALES)[number];
+
+// The following locale types can be used in the locale based formatters:
+// Full locale as reported by the browser, e.g. en-US.
+// May contain a full BCP 47 tag like en-US at runtime; branded over ConstLocale as a type anchor.
+export type BrowserBasedLocale = Brand<ConstLocale, "BrowserBasedLocale">;
+// Locale used in the social media generation
+export type ImageLocale = Brand<ConstLocale, "ImageLocale">;
+// Locale used in the page generateMetadata functions
+export type MetadataLocale = Brand<ConstLocale, "MetadataLocale">;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,9 +1,9 @@
+import type { Brand } from "@/utils/brand";
 import type { Countries } from "@/utils/countries";
 
 import type { PartyYearsSums } from "./loader/party-years-sums";
 
-declare const tags: unique symbol;
-export type ReceiverId = string & { [tags]: { receiverId: never } };
+export type ReceiverId = Brand<string, "ReceiverId">;
 
 export const enum AddressField {
   Country,

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -3,7 +3,7 @@ import type { CountryConfig } from "@/types/country-config";
 import { PartyField } from "@/types/party";
 
 import type { Country } from "./countries";
-import type { ConstLocale } from "./locales";
+import type { ConstLocale, MetadataLocale } from "./locales";
 import type { ReceiverId } from "./types";
 
 import { COUNTRIES } from "./countries";
@@ -15,6 +15,12 @@ export const isValidLocale = (
   if (!locale) return false;
 
   return LOCALES_SET.has(locale as ConstLocale);
+};
+
+export const isValidMetadataLocale = (
+  locale: string | undefined,
+): locale is MetadataLocale => {
+  return isValidLocale(locale);
 };
 
 export const isValidCountry = (country: string): country is Country => {

--- a/tasks/fake-data/generate-fake-data.ts
+++ b/tasks/fake-data/generate-fake-data.ts
@@ -168,11 +168,10 @@ class FakeDataLoader extends DataLoader {
         extracted.push({
           idx: `fake-${year}-${idx++}`,
           [DonationField.DonorName]: `Fake Donor ${j + 1}`,
-          [DonationField.Date]: `${year}-${String(
-            Math.floor(Math.random() * 12) + 1,
-          ).padStart(2, "0")}-${String(
-            Math.floor(Math.random() * 28) + 1,
-          ).padStart(2, "0")}`,
+          [DonationField.Date]: `${year}-${String(((j + 11) % 12) + 1).padStart(
+            2,
+            "0",
+          )}-${String(26 - (j % 26)).padStart(2, "0")}`,
           [DonationField.Amount]: amountPerDonation,
           [DonationField.Receiver]: partyName,
           [DonationField.Address]:

--- a/tasks/social-images/components/donor-header.tsx
+++ b/tasks/social-images/components/donor-header.tsx
@@ -7,7 +7,7 @@ import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { PartySum } from "@/utils/data/get-parties-sum";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { PageLogo } from "@/components/layout/page-logo";
@@ -35,7 +35,7 @@ export const ImageStackedPartyDonations = ({
 }: {
   years: string[];
   donor?: string;
-  locale: ConstLocale;
+  locale: ImageLocale;
   country: CountryConfig;
   donations: Donation[];
 }) => {
@@ -93,7 +93,7 @@ const ImageRankingItem = ({
   party: Party;
   amount: number;
   sum: number;
-  locale: ConstLocale;
+  locale: ImageLocale;
   country: CountryConfig;
 }) => {
   return (
@@ -122,7 +122,7 @@ export const ImagePageHeader = ({
   children,
 }: PropsWithChildren<{
   getTranslations: CreateTranslator;
-  locale: ConstLocale;
+  locale: ImageLocale;
   right?: string | ReactNode;
   country: CountryConfig;
 }>) => {
@@ -161,7 +161,7 @@ export const DonorHeader = ({
   donations,
 }: {
   getTranslations: CreateTranslator;
-  locale: ConstLocale;
+  locale: ImageLocale;
   country: CountryConfig;
   donations: Donation[];
   donor: BigDonor;

--- a/tasks/social-images/components/image-footer.tsx
+++ b/tasks/social-images/components/image-footer.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable react/no-unknown-property */
 
 import type { CountryConfig } from "@/types/country-config";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 
 import { isNotNullandNotUndefined } from "@/utils/array";
 import { formatCompactCountryCurrency, formatDate } from "@/utils/formatter";
@@ -17,7 +17,7 @@ export const ImageFooter = ({
   locale,
 }: {
   getTranslations: CreateTranslator;
-  locale: ConstLocale;
+  locale: ImageLocale;
   country: CountryConfig;
 }) => {
   const t = getTranslations();

--- a/tasks/social-images/components/image-party-header.tsx
+++ b/tasks/social-images/components/image-party-header.tsx
@@ -2,7 +2,7 @@
 
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 import type { Donation } from "@/utils/types";
 
 import { PartyField } from "@/types/party";
@@ -26,7 +26,7 @@ const RankingItem = ({
   name: string;
   amount: number;
   sum: number;
-  locale: ConstLocale;
+  locale: ImageLocale;
   country: CountryConfig;
 }) => {
   return (
@@ -58,7 +58,7 @@ export const ImagePartyHeader = ({
   getTranslations: CreateTranslator;
   country: CountryConfig;
   party: Party;
-  locale: ConstLocale;
+  locale: ImageLocale;
   donations: Donation[];
 }) => {
   const t = getTranslations();

--- a/tasks/social-images/components/image-years-header.tsx
+++ b/tasks/social-images/components/image-years-header.tsx
@@ -7,7 +7,7 @@ import type { PropsWithChildren, ReactNode } from "react";
 import type { CountryConfig } from "@/types/country-config";
 import type { Party } from "@/types/party";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { PageLogo } from "@/components/layout/page-logo";
@@ -36,7 +36,7 @@ export const ImageStackedPartyDonations = ({
 }: {
   years: string[];
   donor?: string;
-  locale: ConstLocale;
+  locale: ImageLocale;
   country: CountryConfig;
   donations: Donation[];
 }) => {
@@ -94,7 +94,7 @@ const ImageRankingItem = ({
   party: Party;
   amount: number;
   sum: number;
-  locale: ConstLocale;
+  locale: ImageLocale;
   country: CountryConfig;
 }) => {
   return (
@@ -122,7 +122,7 @@ export const ImagePageHeader = ({
   country,
   children,
 }: PropsWithChildren<{
-  locale: ConstLocale;
+  locale: ImageLocale;
   getTranslations: CreateTranslator;
   right?: string | ReactNode;
   country: CountryConfig;
@@ -162,7 +162,7 @@ export const ImageYearsHeader = ({
   years,
   donations,
 }: {
-  locale: ConstLocale;
+  locale: ImageLocale;
   getTranslations: CreateTranslator;
   years: string[];
   country: CountryConfig;

--- a/tasks/social-images/generate-images.test.tsx
+++ b/tasks/social-images/generate-images.test.tsx
@@ -12,9 +12,11 @@ import { afterAll, beforeAll, describe, it } from "vitest";
 import type { CountryConfig } from "@/types/country-config";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
+import type { ImageLocale } from "@/utils/locales";
 import type { Donation } from "@/utils/types";
 
 import { PartyField } from "@/types/party";
+import { makeBrand } from "@/utils/brand";
 import { COUNTRIES } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { Features, hasFeature } from "@/utils/features";
@@ -95,189 +97,186 @@ const renderComponent = async (component: JSX.Element) => {
   return toImage(svg);
 };
 
-describe.each(CONST_LOCALES.map((locale) => ({ locale })))(
-  "language $locale",
-  ({ locale }) => {
-    const LOCALE_OUT_DIR = path.join(OUT_DIR, locale);
-    let getTranslations: CreateTranslator;
+describe.each(
+  CONST_LOCALES.map((locale) => ({ locale: makeBrand<ImageLocale>(locale) })),
+)("language $locale", ({ locale }) => {
+  const LOCALE_OUT_DIR = path.join(OUT_DIR, locale);
+  let getTranslations: CreateTranslator;
 
-    beforeAll(async () => {
-      await fs.mkdir(LOCALE_OUT_DIR, { recursive: true });
+  beforeAll(async () => {
+    await fs.mkdir(LOCALE_OUT_DIR, { recursive: true });
 
-      const messages = (
-        await import(`../../src/messages/${locale}.json`, {
-          with: { type: "json" },
-        })
-      ).default;
+    const messages = (
+      await import(`../../src/messages/${locale}.json`, {
+        with: { type: "json" },
+      })
+    ).default;
 
-      getTranslations = (namespace?: string) =>
-        createTranslator({
-          locale,
-          namespace,
-          messages,
-        });
-    });
-
-    afterAll(async () => {
-      const command = `oxipng -o 2 --strip safe ${path.join(LOCALE_OUT_DIR, `cover.png`)}`;
-      console.log(`Optimizing cover with command: ${command}`);
-      cp.execSync(command, {
-        stdio: "inherit",
+    getTranslations = (namespace?: string) =>
+      createTranslator({
+        locale,
+        namespace,
+        messages,
       });
+  });
+
+  afterAll(async () => {
+    const command = `oxipng -o 2 --strip safe ${path.join(LOCALE_OUT_DIR, `cover.png`)}`;
+    console.log(`Optimizing cover with command: ${command}`);
+    cp.execSync(command, {
+      stdio: "inherit",
     });
+  });
 
-    it("renders root page image", async () => {
-      const countriesArray = [...COUNTRIES];
+  it("renders root page image", async () => {
+    const countriesArray = [...COUNTRIES];
 
-      const countryDatas = await Promise.all(
-        countriesArray.map((country) =>
-          Promise.all([
-            country,
-            getCountryConfig(country),
-            getPartyYearsSums(country),
-          ]),
-        ),
-      );
+    const countryDatas = await Promise.all(
+      countriesArray.map((country) =>
+        Promise.all([
+          country,
+          getCountryConfig(country),
+          getPartyYearsSums(country),
+        ]),
+      ),
+    );
 
-      const png = await renderComponent(
-        await RootPageImage(locale, getTranslations, countryDatas),
-      );
+    const png = await renderComponent(
+      await RootPageImage(locale, getTranslations, countryDatas),
+    );
 
-      await fs.writeFile(path.join(LOCALE_OUT_DIR, `cover.png`), png);
-    });
+    await fs.writeFile(path.join(LOCALE_OUT_DIR, `cover.png`), png);
+  });
 
-    describe.each([...COUNTRIES].map((country) => ({ country })))(
-      `country $country`,
-      ({ country }) => {
-        const COUNTRY_OUT_DIR = path.join(LOCALE_OUT_DIR, country);
-        const PARTY_OUT_DIR = path.join(COUNTRY_OUT_DIR, "parties");
-        const YEARS_OUT_DIR = path.join(COUNTRY_OUT_DIR, "years");
-        const DONOR_OUT_DIR = path.join(COUNTRY_OUT_DIR, "donors");
-        let donations: Donation[];
-        let countryConfig: CountryConfig;
-        let yearSums: PartyYearsSums;
-        let biggestDonors: BigDonor[];
+  describe.each([...COUNTRIES].map((country) => ({ country })))(
+    `country $country`,
+    ({ country }) => {
+      const COUNTRY_OUT_DIR = path.join(LOCALE_OUT_DIR, country);
+      const PARTY_OUT_DIR = path.join(COUNTRY_OUT_DIR, "parties");
+      const YEARS_OUT_DIR = path.join(COUNTRY_OUT_DIR, "years");
+      const DONOR_OUT_DIR = path.join(COUNTRY_OUT_DIR, "donors");
+      let donations: Donation[];
+      let countryConfig: CountryConfig;
+      let yearSums: PartyYearsSums;
+      let biggestDonors: BigDonor[];
 
-        beforeAll(async () => {
-          await fs.rm(COUNTRY_OUT_DIR, { recursive: true, force: true });
-          await fs.mkdir(PARTY_OUT_DIR, { recursive: true });
-          await fs.mkdir(YEARS_OUT_DIR, { recursive: true });
-          await fs.mkdir(DONOR_OUT_DIR, { recursive: true });
-          [countryConfig, donations, yearSums, biggestDonors] =
-            await Promise.all([
-              await getCountryConfig(country),
-              await getDonations(country),
-              await getPartyYearsSums(country),
-              await getBiggestDonors(country),
-            ]);
+      beforeAll(async () => {
+        await fs.rm(COUNTRY_OUT_DIR, { recursive: true, force: true });
+        await fs.mkdir(PARTY_OUT_DIR, { recursive: true });
+        await fs.mkdir(YEARS_OUT_DIR, { recursive: true });
+        await fs.mkdir(DONOR_OUT_DIR, { recursive: true });
+        [countryConfig, donations, yearSums, biggestDonors] = await Promise.all(
+          [
+            await getCountryConfig(country),
+            await getDonations(country),
+            await getPartyYearsSums(country),
+            await getBiggestDonors(country),
+          ],
+        );
+      });
+
+      afterAll(async () => {
+        const command = `oxipng -o 2 --strip safe ${COUNTRY_OUT_DIR}/**/*.png`;
+        console.log(`Optimizing images with command: ${command}`);
+        cp.execSync(command, {
+          stdio: "inherit",
         });
+      });
 
-        afterAll(async () => {
-          const command = `oxipng -o 2 --strip safe ${COUNTRY_OUT_DIR}/**/*.png`;
-          console.log(`Optimizing images with command: ${command}`);
-          cp.execSync(command, {
-            stdio: "inherit",
-          });
-        });
+      it(`renders country page image`, async () => {
+        const png = await renderComponent(
+          await CountryPageImage(
+            locale,
+            getTranslations,
+            countryConfig,
+            yearSums,
+          ),
+        );
 
-        it(`renders country page image`, async () => {
+        await fs.writeFile(path.join(COUNTRY_OUT_DIR, `cover.png`), png);
+      });
+
+      it(`renders biggest donors images`, async () => {
+        // if there are no donors, skip rendering donor images
+        if (!hasFeature(countryConfig, Features.Donors)) return;
+
+        for (const donor of biggestDonors) {
           const png = await renderComponent(
-            await CountryPageImage(
+            await DonorImage(
               locale,
               getTranslations,
               countryConfig,
+              donor,
+              donations,
+            ),
+          );
+
+          await fs.writeFile(path.join(DONOR_OUT_DIR, `${donor.id}.png`), png);
+        }
+      });
+
+      it(`renders country party pages image`, async () => {
+        for (const party of countryConfig.parties) {
+          const png = await renderComponent(
+            await PartyPageImage(
+              locale,
+              getTranslations,
+              countryConfig,
+              party[PartyField.Id],
+              donations,
+            ),
+          );
+
+          await fs.writeFile(
+            path.join(PARTY_OUT_DIR, `${party[PartyField.Id]}.png`),
+            png,
+          );
+        }
+      });
+
+      it(`renders country years pages image`, async () => {
+        const countryYears = countryConfig.years;
+
+        // year ranges
+        for (const years of countryConfig.legislativeYears ?? []) {
+          const png = await renderComponent(
+            await CountryYearsPageImage(
+              locale,
+              getTranslations,
+              countryConfig,
+              donations,
+              years,
               yearSums,
             ),
           );
 
-          await fs.writeFile(path.join(COUNTRY_OUT_DIR, `cover.png`), png);
-        });
+          await fs.writeFile(
+            path.join(YEARS_OUT_DIR, `${years.at(0)}-${years.at(-1)}.png`),
+            png,
+          );
+        }
 
-        it(`renders biggest donors images`, async () => {
-          // if there are no donors, skip rendering donor images
-          if (!hasFeature(countryConfig, Features.Donors)) return;
-
-          for (const donor of biggestDonors) {
-            const png = await renderComponent(
-              await DonorImage(
-                locale,
-                getTranslations,
-                countryConfig,
-                donor,
-                donations,
-              ),
-            );
-
-            await fs.writeFile(
-              path.join(DONOR_OUT_DIR, `${donor.id}.png`),
-              png,
-            );
-          }
-        });
-
-        it(`renders country party pages image`, async () => {
-          for (const party of countryConfig.parties) {
-            const png = await renderComponent(
-              await PartyPageImage(
-                locale,
-                getTranslations,
-                countryConfig,
-                party[PartyField.Id],
-                donations,
-              ),
-            );
-
-            await fs.writeFile(
-              path.join(PARTY_OUT_DIR, `${party[PartyField.Id]}.png`),
-              png,
-            );
-          }
-        });
-
-        it(`renders country years pages image`, async () => {
-          const countryYears = countryConfig.years;
-
-          // year ranges
-          for (const years of countryConfig.legislativeYears ?? []) {
-            const png = await renderComponent(
-              await CountryYearsPageImage(
-                locale,
-                getTranslations,
-                countryConfig,
-                donations,
-                years,
-                yearSums,
-              ),
-            );
-
-            await fs.writeFile(
-              path.join(YEARS_OUT_DIR, `${years.at(0)}-${years.at(-1)}.png`),
-              png,
-            );
+        // singular years
+        for (const year of countryYears) {
+          // check if year is in the future and skip
+          if (year > `${new Date().getFullYear()}`) {
+            continue;
           }
 
-          // singular years
-          for (const year of countryYears) {
-            // check if year is in the future and skip
-            if (year > `${new Date().getFullYear()}`) {
-              continue;
-            }
+          const png = await renderComponent(
+            await CountryYearsPageImage(
+              locale,
+              getTranslations,
+              countryConfig,
+              donations,
+              [year],
+              yearSums,
+            ),
+          );
 
-            const png = await renderComponent(
-              await CountryYearsPageImage(
-                locale,
-                getTranslations,
-                countryConfig,
-                donations,
-                [year],
-                yearSums,
-              ),
-            );
-
-            await fs.writeFile(path.join(YEARS_OUT_DIR, `${year}.png`), png);
-          }
-        });
-      },
-    );
-  },
-);
+          await fs.writeFile(path.join(YEARS_OUT_DIR, `${year}.png`), png);
+        }
+      });
+    },
+  );
+});

--- a/tasks/social-images/images/country-page-image.tsx
+++ b/tasks/social-images/images/country-page-image.tsx
@@ -4,7 +4,7 @@
 
 import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 
 import { formatCompactCountryCurrency } from "@/utils/formatter";
 
@@ -27,7 +27,7 @@ const CHART_CONTENT_WIDTH =
   CHART_WIDTH - Y_AXIS_LABEL_WIDTH - Y_AXIS_VALUE_WIDTH;
 
 export const CountryPageImage = async (
-  locale: ConstLocale,
+  locale: ImageLocale,
   getTranslations: CreateTranslator,
   countryConfig: CountryConfig,
   partyYearSums: PartyYearsSums,

--- a/tasks/social-images/images/country-years-page-image.tsx
+++ b/tasks/social-images/images/country-years-page-image.tsx
@@ -1,6 +1,6 @@
 import type { CountryConfig } from "@/types/country-config";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 import type { Donation } from "@/utils/types";
 
 import { donationYear } from "@/utils/date";
@@ -12,7 +12,7 @@ import { ImageYearsHeader } from "../components/image-years-header";
 import { ThumbnailWrapper } from "../components/utils";
 
 export const CountryYearsPageImage = async (
-  locale: ConstLocale,
+  locale: ImageLocale,
   getTranslations: CreateTranslator,
   countryConfig: CountryConfig,
   donations: Donation[],

--- a/tasks/social-images/images/donor-image.tsx
+++ b/tasks/social-images/images/donor-image.tsx
@@ -1,6 +1,6 @@
 import type { CountryConfig } from "@/types/country-config";
 import type { BigDonor } from "@/utils/loader/biggest-donors";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 import type { Donation } from "@/utils/types";
 
 import { DonationField } from "@/utils/types";
@@ -12,7 +12,7 @@ import { ImageFooter } from "../components/image-footer";
 import { ThumbnailWrapper } from "../components/utils";
 
 export const DonorImage = async (
-  locale: ConstLocale,
+  locale: ImageLocale,
   getTranslations: CreateTranslator,
   countryConfig: CountryConfig,
   donor: BigDonor,

--- a/tasks/social-images/images/party-page-image.tsx
+++ b/tasks/social-images/images/party-page-image.tsx
@@ -1,5 +1,5 @@
 import type { CountryConfig } from "@/types/country-config";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { PartyField } from "@/types/party";
@@ -12,7 +12,7 @@ import { ImagePartyHeader } from "../components/image-party-header";
 import { ThumbnailWrapper } from "../components/utils";
 
 export const PartyPageImage = async (
-  locale: ConstLocale,
+  locale: ImageLocale,
   getTranslations: CreateTranslator,
   countryConfig: CountryConfig,
   partyId: ReceiverId,

--- a/tasks/social-images/images/root-page-image.tsx
+++ b/tasks/social-images/images/root-page-image.tsx
@@ -3,7 +3,7 @@
 import type { CountryConfig } from "@/types/country-config";
 import type { Country } from "@/utils/countries";
 import type { PartyYearsSums } from "@/utils/loader/party-years-sums";
-import type { ConstLocale } from "@/utils/locales";
+import type { ImageLocale } from "@/utils/locales";
 
 /* eslint-disable react/no-unknown-property */
 import { PageLogo } from "@/components/layout/page-logo";
@@ -15,7 +15,7 @@ import { ImageMetaCard } from "../components/image-meta-card";
 import { ThumbnailWrapper } from "../components/utils";
 
 export const RootPageImage = async (
-  locale: ConstLocale,
+  locale: ImageLocale,
   getTranslations: CreateTranslator,
   countryDatas: [Country, CountryConfig, PartyYearsSums][],
 ) => {

--- a/tasks/social-media/generate-social-media-posts.ts
+++ b/tasks/social-media/generate-social-media-posts.ts
@@ -10,11 +10,12 @@ import {
 import { promisify } from "util";
 
 import type { CountryConfig } from "@/types/country-config";
-import type { ConstLocale } from "@/utils/locales";
+import type { BrowserBasedLocale, ConstLocale } from "@/utils/locales";
 import type { StrictNamespacedTranslator } from "@/utils/translator";
 import type { Donation, ReceiverId } from "@/utils/types";
 
 import { PartyField } from "@/types/party";
+import { makeBrand } from "@/utils/brand";
 import { Country, getCountryName, getParty } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { formatCompactCountryCurrency } from "@/utils/formatter";
@@ -236,6 +237,9 @@ const main = async () => {
     log("Found party diffs:", partyDiffs);
 
     const lang = countryTranslations[country];
+    // We cast the base language to a BrowserBasedLocale for compatibility with formatters.
+    // In this Node.js context, we don't have a navigator, so we stick to the base language.
+    const browserLang = makeBrand<BrowserBasedLocale>(lang);
 
     const messages = await import(`../../src/messages/${lang}.json`, {
       with: { type: "json" },
@@ -262,9 +266,9 @@ const main = async () => {
         ],
         delta:
           deltaPrefix(data.delta) +
-          formatCompactCountryCurrency(lang, data.delta, countryConfig),
+          formatCompactCountryCurrency(browserLang, data.delta, countryConfig),
         count: deltaPrefix(data.count) + data.count,
-        sum: formatCompactCountryCurrency(lang, data.sum, countryConfig),
+        sum: formatCompactCountryCurrency(browserLang, data.sum, countryConfig),
       })}\n`;
     });
 
@@ -281,7 +285,7 @@ const main = async () => {
         otherParties: otherParties.length,
         otherDelta:
           deltaPrefix(otherDelta) +
-          formatCompactCountryCurrency(lang, otherDelta, countryConfig),
+          formatCompactCountryCurrency(browserLang, otherDelta, countryConfig),
         otherCount: deltaPrefix(otherCount) + otherCount,
       })}`;
     }

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "vitest";
 
+import type { BrowserBasedLocale } from "@/utils/locales";
+
+import { makeBrand } from "@/utils/brand";
 import { Country } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { dateDiffInDays } from "@/utils/date";
@@ -12,46 +15,50 @@ import {
   formatYearsRange,
 } from "@/utils/formatter";
 
+// Static locales branded as BrowserBasedLocale for unit testing formatters.
+const EN = makeBrand<BrowserBasedLocale>("en");
+const DE = makeBrand<BrowserBasedLocale>("de");
+
 test("format EUR", async () => {
   const countryConfig = await getCountryConfig(Country.germany);
 
-  expect(formatCountryCurrency("en", 0, countryConfig)).toBe("€0.00");
-  expect(formatCountryCurrency("en", 100, countryConfig)).toBe("€100.00");
+  expect(formatCountryCurrency(EN, 0, countryConfig)).toBe("€0.00");
+  expect(formatCountryCurrency(EN, 100, countryConfig)).toBe("€100.00");
 
-  expect(formatCountryCurrency("de", 1, countryConfig)).toBe("1,00 €");
-  expect(formatCountryCurrency("de", 200, countryConfig)).toBe("200,00 €");
+  expect(formatCountryCurrency(DE, 1, countryConfig)).toBe("1,00 €");
+  expect(formatCountryCurrency(DE, 200, countryConfig)).toBe("200,00 €");
 });
 
 test("format CHF", async () => {
   const countryConfig = await getCountryConfig(Country.switzerland);
 
-  expect(formatCountryCurrency("en", 0, countryConfig)).toBe("CHF 0.00");
-  expect(formatCountryCurrency("en", 100, countryConfig)).toBe("CHF 100.00");
+  expect(formatCountryCurrency(EN, 0, countryConfig)).toBe("CHF 0.00");
+  expect(formatCountryCurrency(EN, 100, countryConfig)).toBe("CHF 100.00");
 
-  expect(formatCountryCurrency("de", 1, countryConfig)).toBe("1,00 CHF");
-  expect(formatCountryCurrency("de", 200, countryConfig)).toBe("200,00 CHF");
+  expect(formatCountryCurrency(DE, 1, countryConfig)).toBe("1,00 CHF");
+  expect(formatCountryCurrency(DE, 200, countryConfig)).toBe("200,00 CHF");
 });
 
 test("formatDate", () => {
   const date1 = new Date("2023-11-15T08:31:57.418Z");
   const date2 = new Date("2023-11-11T08:31:57.418Z").getTime();
 
-  expect(formatDate("en", date1)).toBe("November 15, 2023");
-  expect(formatDate("en", date2)).toBe("November 11, 2023");
+  expect(formatDate(EN, date1)).toBe("November 15, 2023");
+  expect(formatDate(EN, date2)).toBe("November 11, 2023");
 
-  expect(formatDate("de", date1)).toBe("15. November 2023");
-  expect(formatDate("de", date2)).toBe("11. November 2023");
+  expect(formatDate(DE, date1)).toBe("15. November 2023");
+  expect(formatDate(DE, date2)).toBe("11. November 2023");
 });
 
 test("formatTwoDigitDate", () => {
   const date1 = new Date("2023-11-15T08:31:57.418Z");
   const date2 = new Date("2023-11-11T08:31:57.418Z").getTime();
 
-  expect(formatTwoDigitDate("en", date1)).toBe("11/15/23");
-  expect(formatTwoDigitDate("en", date2)).toBe("11/11/23");
+  expect(formatTwoDigitDate(EN, date1)).toBe("11/15/23");
+  expect(formatTwoDigitDate(EN, date2)).toBe("11/11/23");
 
-  expect(formatTwoDigitDate("de", date1)).toBe("15.11.23");
-  expect(formatTwoDigitDate("de", date2)).toBe("11.11.23");
+  expect(formatTwoDigitDate(DE, date1)).toBe("15.11.23");
+  expect(formatTwoDigitDate(DE, date2)).toBe("11.11.23");
 });
 
 test("formatRelativeDate", () => {
@@ -59,9 +66,9 @@ test("formatRelativeDate", () => {
   const date2 = new Date("2023-11-11T08:31:57.418Z");
   const diff = dateDiffInDays(date1, date2);
 
-  expect(formatRelativeDate("en", diff, "days")).toBe("4 days ago");
+  expect(formatRelativeDate(EN, diff, "days")).toBe("4 days ago");
 
-  expect(formatRelativeDate("de", diff, "days")).toBe("vor 4 Tagen");
+  expect(formatRelativeDate(DE, diff, "days")).toBe("vor 4 Tagen");
 });
 
 test("formatRelativeDate today", () => {
@@ -69,16 +76,16 @@ test("formatRelativeDate today", () => {
   const date2 = new Date("2023-11-15T12:31:57.418Z");
   const diff = dateDiffInDays(date1, date2);
 
-  expect(formatRelativeDate("en", diff, "days")).toBe("");
-  expect(formatRelativeDate("de", diff, "days")).toBe("");
+  expect(formatRelativeDate(EN, diff, "days")).toBe("");
+  expect(formatRelativeDate(DE, diff, "days")).toBe("");
 });
 
 test("formatPercentFormat", () => {
-  expect(formatPercentFormat("en", 0.5)).toBe("50%");
-  expect(formatPercentFormat("en", 0.25)).toBe("25%");
+  expect(formatPercentFormat(EN, 0.5)).toBe("50%");
+  expect(formatPercentFormat(EN, 0.25)).toBe("25%");
 
-  expect(formatPercentFormat("de", 0.5)).toBe("50 %");
-  expect(formatPercentFormat("de", 0.25)).toBe("25 %");
+  expect(formatPercentFormat(DE, 0.5)).toBe("50 %");
+  expect(formatPercentFormat(DE, 0.25)).toBe("25 %");
 });
 
 test("formatYearsRange", () => {


### PR DESCRIPTION
## Description

use navigator locale in formatters if it matches selected language

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Data update/addition
- [ ] Documentation update
- [ ] Refactoring

## Related Issues

Fixes #34

## Testing

- [x] Unit tests pass (`pnpm test:unit`)
- [x] Lint passes (`pnpm lint`)
- [x] E2E tests pass (`pnpm test:e2e`) - if UI changes
