### PR TITLE
refactor: extract scoped client messages to reduce hydration bloat

### DIFF
--- a/e2e/enterprise.spec.ts
+++ b/e2e/enterprise.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from "@playwright/test";
+
+import { test } from "./util/fixture";
+
+test.describe("Enterprise page", () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}/enterprise`);
+  });
+
+  test("is accessible and has correct headings", async ({
+    accessibility,
+    enterprisePage,
+  }) => {
+    await expect(enterprisePage.heading).toBeVisible();
+    await expect(enterprisePage.formTitle).toBeVisible();
+
+    await accessibility.check();
+  });
+
+  test("form has required inputs", async ({ enterprisePage }) => {
+    await expect(enterprisePage.fullNameInput).toBeVisible();
+    await expect(enterprisePage.workEmailInput).toBeVisible();
+    await expect(enterprisePage.organizationInput).toBeVisible();
+    await expect(enterprisePage.queryRequestInput).toBeVisible();
+    await expect(enterprisePage.submitButton).toBeVisible();
+  });
+});

--- a/e2e/fixtures/enterprise.ts
+++ b/e2e/fixtures/enterprise.ts
@@ -1,0 +1,31 @@
+import { PageObject } from "../util/page";
+
+export class EnterprisePage extends PageObject {
+  public readonly heading = this.page.getByRole("heading", {
+    name: this.translations("enterprise.heading"),
+  });
+
+  public readonly formTitle = this.page.getByRole("heading", {
+    name: this.translations("enterprise.form.formTitle"),
+  });
+
+  public readonly fullNameInput = this.page.getByLabel(
+    this.translations("enterprise.form.labelFullName"),
+  );
+
+  public readonly workEmailInput = this.page.getByLabel(
+    this.translations("enterprise.form.labelWorkEmail"),
+  );
+
+  public readonly organizationInput = this.page.getByLabel(
+    this.translations("enterprise.form.labelOrganization"),
+  );
+
+  public readonly queryRequestInput = this.page.getByLabel(
+    this.translations("enterprise.form.labelQueryRequest"),
+  );
+
+  public readonly submitButton = this.page.getByRole("button", {
+    name: this.translations("enterprise.form.buttonSubmit"),
+  });
+}

--- a/e2e/util/fixture.ts
+++ b/e2e/util/fixture.ts
@@ -12,6 +12,7 @@ import { Accessibility } from "../fixtures/accessibility";
 import { ClipboardAccess } from "../fixtures/clipboard-access";
 import { DonorPage } from "../fixtures/donor";
 import { DonorsPage } from "../fixtures/donors";
+import { EnterprisePage } from "../fixtures/enterprise";
 import { GlobalSearch } from "../fixtures/global-search";
 import { HistoryPage } from "../fixtures/history";
 import { HomePage } from "../fixtures/home";
@@ -39,6 +40,7 @@ type SharedFixtures = {
   donorPage: DonorPage;
   partyPage: PartyPage;
   partyDonorsPage: DonorsPage;
+  enterprisePage: EnterprisePage;
 
   tools: Tools;
 
@@ -55,6 +57,37 @@ type SharedFixtures = {
 };
 
 export const test = base.extend<SharedFixtures>({
+  page: async ({ page }, use) => {
+    const consoleErrors: string[] = [];
+
+    const handleConsole = (msg: { text: () => string }) => {
+      const text = msg.text();
+      if (text.includes("MISSING_MESSAGE")) {
+        consoleErrors.push(`Console error: ${text}`);
+      }
+    };
+
+    const handlePageError = (exception: Error) => {
+      const text = exception.message;
+      if (text.includes("MISSING_MESSAGE")) {
+        consoleErrors.push(`Page exception: ${text}`);
+      }
+    };
+
+    page.on("console", handleConsole);
+    page.on("pageerror", handlePageError);
+
+    await use(page);
+
+    page.off("console", handleConsole);
+    page.off("pageerror", handlePageError);
+
+    if (consoleErrors.length > 0) {
+      throw new Error(
+        `Test failed due to missing translation(s) in console:\n${consoleErrors.join("\n")}`,
+      );
+    }
+  },
   props: async ({ context, page, translations, locale }, use) =>
     use({
       page,
@@ -125,6 +158,9 @@ export const test = base.extend<SharedFixtures>({
   },
   rootPage: async ({ props }, use) => {
     await use(new RootPage(props));
+  },
+  enterprisePage: async ({ props }, use) => {
+    await use(new EnterprisePage(props));
   },
   country: [Country.germany, { option: true }],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,8 @@ export default defineConfig({
   timeout: isCI ? 60 * 1000 : undefined,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.CI ? "github" : "line",
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/src/app/[locale]/[country]/[years]/layout.tsx
+++ b/src/app/[locale]/[country]/[years]/layout.tsx
@@ -7,6 +7,7 @@ import { notFound, redirect } from "next/navigation";
 import type { TabItem } from "@/components/tabs";
 
 import { DynamicAbsoluteMultiplePartySumsGradient } from "@/components/charts/dynamic-stacked-party-line";
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { PageHeader } from "@/components/layout/page-header";
 import { LastModifiedSchema } from "@/components/schema";
 import { NavigationTabs } from "@/components/tabs";
@@ -18,6 +19,8 @@ import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { Features, hasFeature } from "@/utils/features";
 import { formatYearsRange } from "@/utils/formatter";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import {
   getPartyYearsSums,
   hasYearSums,
@@ -129,10 +132,11 @@ export default async function YearsLayout(
   const { locale, country } = params;
   const years = deserializeYears(params.years);
 
-  const [t, countryConfig, partySums] = await Promise.all([
+  const [t, countryConfig, partySums, messages] = await Promise.all([
     getTranslations({ locale }),
     getCountryConfig(country),
     getPartyYearsSums(country),
+    getMessagesForLocale(locale),
   ]);
 
   if (!years.length || !hasKnownYearRange(years, countryConfig)) {
@@ -181,8 +185,25 @@ export default async function YearsLayout(
     year: years.at(-1)!,
   });
 
+  const pageMessages = pick(messages, [
+    "overview",
+    "changes",
+    "donors",
+    "timeline",
+    "origin",
+    "stacked_years",
+    "years",
+    "chart",
+    "state",
+    "countries",
+    "ref_countries",
+    "data",
+    "donation_type",
+    "per_month",
+  ]);
+
   return (
-    <>
+    <ScopedClientIntlProvider messages={pageMessages}>
       {lastDonation ? <LastModifiedSchema dateModified={lastDonation} /> : null}
       <DynamicAbsoluteMultiplePartySumsGradient
         partyYearsSums={partySums}
@@ -218,6 +239,6 @@ export default async function YearsLayout(
       <div className="container mx-auto px-4">
         <YearsFooterNav years={years} locale={locale} country={countryConfig} />
       </div>
-    </>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/[country]/donor/[donorId]/page.tsx
+++ b/src/app/[locale]/[country]/donor/[donorId]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { THUMBNAIL_PREFIX } from "@/utils/config";
 import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
@@ -16,6 +17,8 @@ import {
   formatCompactCountryCurrency,
   formatCountryCurrency,
 } from "@/utils/formatter";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import { getBiggestDonors } from "@/utils/loader/biggest-donors";
 import { baseOpenGraph, baseTwitter, generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -142,13 +145,29 @@ export default async function DonorPageLayout(
 
   const { country, donorId } = params;
 
-  const [countryConfig, donorMeta] = await Promise.all([
+  const [countryConfig, donorMeta, messages] = await Promise.all([
     getCountryConfig(country),
     getDonorMeta(country, donorId),
+    getMessagesForLocale(params.locale),
+  ]);
+
+  const pageMessages = pick(messages, [
+    "donor",
+    "biggest_donations",
+    "countries",
+    "data",
+    "chart",
+    "sort",
+    "common",
+    "search",
+    "donor_type",
+    "years",
+    "donation_type",
+    "changes",
   ]);
 
   return (
-    <>
+    <ScopedClientIntlProvider messages={pageMessages}>
       <DonorPageHead
         donorId={donorId}
         country={country}
@@ -160,6 +179,6 @@ export default async function DonorPageLayout(
         country={country}
         countryConfig={countryConfig}
       />
-    </>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/[country]/page.tsx
+++ b/src/app/[locale]/[country]/page.tsx
@@ -15,6 +15,7 @@ import { BiggestDonationsHero } from "@/components/donations/biggest-donations-h
 import { DonorsHero } from "@/components/donors/donors-hero";
 import { ExternalThanks } from "@/components/external-thanks";
 import { HistoryComponent } from "@/components/history-component";
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { DetectedCountry } from "@/components/layout/detected-country";
 import { PartiesHero } from "@/components/parties/parties-hero";
 import { Translation } from "@/components/translation";
@@ -27,6 +28,8 @@ import {
 } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { Features, hasFeature } from "@/utils/features";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import { getBiggestDonors } from "@/utils/loader/biggest-donors";
 import { loadCountryData } from "@/utils/loader/country-data-loaders";
 import {
@@ -80,6 +83,7 @@ export default async function YearsPage(
     partySums,
     biggestDonors,
     biggestDonations,
+    messages,
   ] = await Promise.all([
     getTranslations({ locale, namespace: "ref_countries" }),
     getTranslations({ locale, namespace: "home" }),
@@ -88,6 +92,7 @@ export default async function YearsPage(
     getPartyYearsSums(country),
     getBiggestDonors(country),
     loadCountryData(country, "biggestDonations"),
+    getMessagesForLocale(locale),
   ]);
 
   // Get years that actually have donations by checking partySums
@@ -101,8 +106,17 @@ export default async function YearsPage(
   const currentYear = yearsWithDonations[0];
   const previousYear = yearsWithDonations[1];
 
+  const pageMessages = pick(messages, [
+    "home",
+    "biggest_donations",
+    "countries",
+    "ref_countries",
+    "stacked_years",
+    "chart",
+  ]);
+
   return (
-    <>
+    <ScopedClientIntlProvider messages={pageMessages}>
       <AbsoluteMultipleColorsGradient
         colors={[{ color: "#3730a3", width: 100 }]}
       />
@@ -366,6 +380,6 @@ export default async function YearsPage(
       ) : null}
 
       <ExternalThanks country={countryConfig} locale={locale} />
-    </>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/[country]/party/[partyId]/layout.tsx
+++ b/src/app/[locale]/[country]/party/[partyId]/layout.tsx
@@ -11,6 +11,7 @@ import {
   FormattedCountryCurrency,
   FormattedNumber,
 } from "@/components/browser-based-formatter";
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { PageHeader } from "@/components/layout/page-header";
 import { MetaCard } from "@/components/meta-card";
 import { LastModifiedSchema } from "@/components/schema";
@@ -23,6 +24,8 @@ import { THUMBNAIL_PREFIX } from "@/utils/config";
 import { findCorrectParty, getParty } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { Features, hasFeature } from "@/utils/features";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import {
   getPartyYearsSums,
   lastPartyStatsDonation,
@@ -115,12 +118,14 @@ export default async function PartyLayout(
 
   const { children } = props;
 
-  const [t, countryConfig, partyYearsSums, tCommon] = await Promise.all([
-    getTranslations({ locale }),
-    getCountryConfig(country),
-    getPartyYearsSums(country),
-    getTranslations({ locale, namespace: "common" }),
-  ]);
+  const [t, countryConfig, partyYearsSums, tCommon, messages] =
+    await Promise.all([
+      getTranslations({ locale }),
+      getCountryConfig(country),
+      getPartyYearsSums(country),
+      getTranslations({ locale, namespace: "common" }),
+      getMessagesForLocale(locale),
+    ]);
 
   if (!isValidParty(partyId, countryConfig)) {
     const correctParty = findCorrectParty(countryConfig, partyId);
@@ -176,8 +181,27 @@ export default async function PartyLayout(
     partyId,
   });
 
+  const pageMessages = pick(messages, [
+    "party",
+    "changes",
+    "donors",
+    "origin",
+    "timeline",
+    "per_year_party",
+    "per_month",
+    "per_year",
+    "chart",
+    "state",
+    "countries",
+    "ref_countries",
+    "data",
+    "donor_type",
+    "years",
+    "donation_type",
+  ]);
+
   return (
-    <>
+    <ScopedClientIntlProvider messages={pageMessages}>
       {lastDonation ? <LastModifiedSchema dateModified={lastDonation} /> : null}
       <AbsoluteMultipleColorsGradient
         colors={[
@@ -247,6 +271,6 @@ export default async function PartyLayout(
         </div>
       </div>
       {children}
-    </>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/[country]/tools/bar-chart-race/page.tsx
+++ b/src/app/[locale]/[country]/tools/bar-chart-race/page.tsx
@@ -3,9 +3,12 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { Article } from "@/components/layout/article";
 import { getCountryConfig } from "@/utils/data/get-country-config";
 import { Features, hasFeature } from "@/utils/features";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import { LOCALES } from "@/utils/locales";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -53,22 +56,27 @@ export default async function Page(
 
   const { country } = params;
 
-  const [tBarChartRace, countryConfig] = await Promise.all([
+  const [tBarChartRace, countryConfig, messages] = await Promise.all([
     getTranslations({ locale: params.locale, namespace: "bar_chart_race" }),
     getCountryConfig(country),
+    getMessagesForLocale(params.locale),
   ]);
 
   if (!hasFeature(countryConfig, Features.Date)) {
     return notFound();
   }
 
+  const pageMessages = pick(messages, ["bar_chart_race", "chart", "actions"]);
+
   return (
-    <Article title={tBarChartRace("title")}>
-      <>
-        <p className="mb-8 max-w-prose">{tBarChartRace("description")}</p>
-        <p className="mb-8 max-w-prose text-sm">{tBarChartRace("note")}</p>
-        <RacingBars countryConfig={countryConfig} />
-      </>
-    </Article>
+    <ScopedClientIntlProvider messages={pageMessages}>
+      <Article title={tBarChartRace("title")}>
+        <>
+          <p className="mb-8 max-w-prose">{tBarChartRace("description")}</p>
+          <p className="mb-8 max-w-prose text-sm">{tBarChartRace("note")}</p>
+          <RacingBars countryConfig={countryConfig} />
+        </>
+      </Article>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/[country]/tools/compare/page.tsx
+++ b/src/app/[locale]/[country]/tools/compare/page.tsx
@@ -3,10 +3,13 @@ import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { Article } from "@/components/layout/article";
 import { PartyComparison } from "@/components/parties/party-comparison";
 import { COUNTRIES } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import { LOCALES } from "@/utils/locales";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -53,18 +56,29 @@ export default async function Page(
 
   const { country } = params;
 
-  const [countryConfig, tCompareParties] = await Promise.all([
+  const [countryConfig, tCompareParties, messages] = await Promise.all([
     getCountryConfig(country),
     getTranslations({
       locale: params.locale,
       namespace: "compare_parties_page",
     }),
+    getMessagesForLocale(params.locale),
+  ]);
+
+  const pageMessages = pick(messages, [
+    "compare_parties_page",
+    "compare_parties",
+    "donor_type",
+    "chart",
+    "bar_chart_race",
   ]);
 
   return (
-    <Article title={tCompareParties("title")}>
-      <p className="mb-8 max-w-prose">{tCompareParties("description")}</p>
-      <PartyComparison countryConfig={countryConfig} />
-    </Article>
+    <ScopedClientIntlProvider messages={pageMessages}>
+      <Article title={tCompareParties("title")}>
+        <p className="mb-8 max-w-prose">{tCompareParties("description")}</p>
+        <PartyComparison countryConfig={countryConfig} />
+      </Article>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/[country]/tools/data/page.tsx
+++ b/src/app/[locale]/[country]/tools/data/page.tsx
@@ -6,11 +6,14 @@ import { notFound } from "next/navigation";
 
 import { CitationGenerator } from "@/components/citation/citation-generator";
 import { DataExport } from "@/components/data-export";
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { Article } from "@/components/layout/article";
 import { Translation } from "@/components/translation";
 import { DATA_LICENSE } from "@/utils/config";
 import { COUNTRIES, getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import { LOCALES } from "@/utils/locales";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -57,74 +60,32 @@ export default async function Page(
 
   const { locale, country } = params;
 
-  const [tExport, tCountries, tNavigation, countryConfig] = await Promise.all([
-    getTranslations({ locale, namespace: "export" }),
-    getTranslations({ locale, namespace: "countries" }),
-    getTranslations({ locale, namespace: "navigation" }),
-    getCountryConfig(country),
-  ]);
+  const [tExport, tCountries, tNavigation, countryConfig, messages] =
+    await Promise.all([
+      getTranslations({ locale, namespace: "export" }),
+      getTranslations({ locale, namespace: "countries" }),
+      getTranslations({ locale, namespace: "navigation" }),
+      getCountryConfig(country),
+      getMessagesForLocale(params.locale),
+    ]);
+
+  const pageMessages = pick(messages, ["export", "citation", "donor_type"]);
 
   return (
-    <Article title={tExport("title")}>
-      <div className="space-y-6">
-        <p>
-          <Translation
-            t={tExport}
-            translationId={"p0"}
-            variables={{
-              country: getCountryName(countryConfig, tCountries),
-              license: (
-                <a
-                  href="https://creativecommons.org/licenses/by/4.0/deed.en"
-                  target="_blank"
-                  rel={"noopener noreferrer"}
-                  className="hover:text-primary-800 dark:hover:text-primary-400 underline"
-                >
-                  {DATA_LICENSE}
-                </a>
-              ),
-            }}
-          />
-        </p>
-        <p>
-          <Translation
-            t={tExport}
-            translationId={"p1"}
-            variables={{
-              source: (
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={countryConfig.source.url}
-                  className="hover:text-primary-800 dark:hover:text-primary-400 underline"
-                >
-                  {countryConfig.source.name}
-                </a>
-              ),
-              transparency: (
-                <Link
-                  href={`/${locale}/${countryConfig.id}/transparency`}
-                  prefetch={false}
-                  rel="nofollow"
-                  className="hover:text-primary-800 dark:hover:text-primary-400 underline"
-                >
-                  {tNavigation("transparency")}
-                </Link>
-              ),
-            }}
-          />
-        </p>
-        <p>
-          {
+    <ScopedClientIntlProvider messages={pageMessages}>
+      <Article title={tExport("title")}>
+        <div className="space-y-6">
+          <p>
             <Translation
               t={tExport}
-              translationId={"license"}
+              translationId={"p0"}
               variables={{
+                country: getCountryName(countryConfig, tCountries),
                 license: (
                   <a
-                    href="https://creativecommons.org/licenses/by/4.0/"
+                    href="https://creativecommons.org/licenses/by/4.0/deed.en"
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel={"noopener noreferrer"}
                     className="hover:text-primary-800 dark:hover:text-primary-400 underline"
                   >
                     {DATA_LICENSE}
@@ -132,10 +93,58 @@ export default async function Page(
                 ),
               }}
             />
-          }
-        </p>
-        <DataExport country={countryConfig} locale={locale} />
-      </div>
-    </Article>
+          </p>
+          <p>
+            <Translation
+              t={tExport}
+              translationId={"p1"}
+              variables={{
+                source: (
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={countryConfig.source.url}
+                    className="hover:text-primary-800 dark:hover:text-primary-400 underline"
+                  >
+                    {countryConfig.source.name}
+                  </a>
+                ),
+                transparency: (
+                  <Link
+                    href={`/${locale}/${countryConfig.id}/transparency`}
+                    prefetch={false}
+                    rel="nofollow"
+                    className="hover:text-primary-800 dark:hover:text-primary-400 underline"
+                  >
+                    {tNavigation("transparency")}
+                  </Link>
+                ),
+              }}
+            />
+          </p>
+          <p>
+            {
+              <Translation
+                t={tExport}
+                translationId={"license"}
+                variables={{
+                  license: (
+                    <a
+                      href="https://creativecommons.org/licenses/by/4.0/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-primary-800 dark:hover:text-primary-400 underline"
+                    >
+                      {DATA_LICENSE}
+                    </a>
+                  ),
+                }}
+              />
+            }
+          </p>
+          <DataExport country={countryConfig} locale={locale} />
+        </div>
+      </Article>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/[country]/transparency/page.tsx
+++ b/src/app/[locale]/[country]/transparency/page.tsx
@@ -4,9 +4,12 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
 
 import { DynamicTransparencyPageContent } from "@/app/[locale]/[country]/transparency/transparency-list";
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { Article } from "@/components/layout/article";
 import { getCountryName } from "@/utils/countries";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import { LOCALES } from "@/utils/locales";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -52,40 +55,46 @@ export default async function Page(
 
   const { country } = params;
 
-  const [tTransparency, tCountries, countryConfig] = await Promise.all([
-    getTranslations({ locale: params.locale, namespace: "transparency" }),
-    getTranslations({ locale: params.locale, namespace: "countries" }),
-    getCountryConfig(country),
-  ]);
+  const [tTransparency, tCountries, countryConfig, messages] =
+    await Promise.all([
+      getTranslations({ locale: params.locale, namespace: "transparency" }),
+      getTranslations({ locale: params.locale, namespace: "countries" }),
+      getCountryConfig(country),
+      getMessagesForLocale(params.locale),
+    ]);
+
+  const pageMessages = pick(messages, ["transparency", "countries"]);
 
   return (
-    <Article title={tTransparency("title")}>
-      <DynamicTransparencyPageContent
-        countryConfig={countryConfig}
-        texts={{
-          filteredReceivers: {
-            title: tTransparency("section.filtered_receivers"),
-            p0: tTransparency("filtered_receivers.p0"),
-            p1: tTransparency("filtered_receivers.p1"),
-          },
-          filteredDonors: {
-            title: tTransparency("section.filtered_donors"),
-            p0: tTransparency("filtered_donors.p0"),
-            p1: tTransparency("filtered_donors.p1"),
-          },
-          normalizedReceivers: {
-            title: tTransparency("receivers.title"),
-            p0: tTransparency("receivers.p0", {
-              country: getCountryName(countryConfig, tCountries),
-            }),
-          },
-          aggregatedDonors: {
-            title: tTransparency("section.aggregated"),
-            p0: tTransparency("p0"),
-            p1: tTransparency("p1"),
-          },
-        }}
-      />
-    </Article>
+    <ScopedClientIntlProvider messages={pageMessages}>
+      <Article title={tTransparency("title")}>
+        <DynamicTransparencyPageContent
+          countryConfig={countryConfig}
+          texts={{
+            filteredReceivers: {
+              title: tTransparency("section.filtered_receivers"),
+              p0: tTransparency("filtered_receivers.p0"),
+              p1: tTransparency("filtered_receivers.p1"),
+            },
+            filteredDonors: {
+              title: tTransparency("section.filtered_donors"),
+              p0: tTransparency("filtered_donors.p0"),
+              p1: tTransparency("filtered_donors.p1"),
+            },
+            normalizedReceivers: {
+              title: tTransparency("receivers.title"),
+              p0: tTransparency("receivers.p0", {
+                country: getCountryName(countryConfig, tCountries),
+              }),
+            },
+            aggregatedDonors: {
+              title: tTransparency("section.aggregated"),
+              p0: tTransparency("p0"),
+              p1: tTransparency("p1"),
+            },
+          }}
+        />
+      </Article>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/enterprise/page.tsx
+++ b/src/app/[locale]/enterprise/page.tsx
@@ -6,8 +6,11 @@ import React from "react";
 
 import { EnterpriseContactForm } from "@/app/[locale]/enterprise/_components/enterprise-contact-form";
 import { AbsoluteMultipleColorsGradient } from "@/components/absolute-multiple-colors-gradient";
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import { Article } from "@/components/layout/article";
 import { NonCountryRootLayout } from "@/components/layout/non-country-root-layout";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import { generateAlternates } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
 import { isValidLocale } from "@/utils/validate";
@@ -40,317 +43,331 @@ export default async function Page(props: PageProps<"/[locale]/enterprise">) {
 
   const { locale } = params;
 
-  const tEnterprise = await getTranslations({
-    locale,
-    namespace: "enterprise",
-  });
+  const [tEnterprise, messages] = await Promise.all([
+    getTranslations({ locale, namespace: "enterprise" }),
+    getMessagesForLocale(locale),
+  ]);
+
+  const pageMessages = pick(messages, ["enterprise", "errors"]);
 
   return (
-    <NonCountryRootLayout locale={locale}>
-      <AbsoluteMultipleColorsGradient
-        colors={[{ color: "#3730a3", width: 100 }]}
-      />
-      <Article fullWidth={true}>
-        <div className="space-y-16 py-12 text-zinc-900 selection:bg-zinc-900 selection:text-white md:py-20 dark:text-zinc-100 dark:selection:bg-white dark:selection:text-black">
-          {/* 1. Hero Section */}
-          <section className="mx-auto max-w-7xl space-y-6 px-4 md:px-8">
-            <h1 className="max-w-4xl font-sans text-4xl leading-[1.05] font-extrabold tracking-tight text-zinc-900 uppercase sm:text-5xl md:text-6xl dark:text-zinc-50">
-              {tEnterprise("heading")}
-            </h1>
+    <ScopedClientIntlProvider messages={pageMessages}>
+      <NonCountryRootLayout locale={locale}>
+        <AbsoluteMultipleColorsGradient
+          colors={[{ color: "#3730a3", width: 100 }]}
+        />
+        <Article fullWidth={true}>
+          <div className="space-y-16 py-12 text-zinc-900 selection:bg-zinc-900 selection:text-white md:py-20 dark:text-zinc-100 dark:selection:bg-white dark:selection:text-black">
+            {/* 1. Hero Section */}
+            <section className="mx-auto max-w-7xl space-y-6 px-4 md:px-8">
+              <h1 className="max-w-4xl font-sans text-4xl leading-[1.05] font-extrabold tracking-tight text-zinc-900 uppercase sm:text-5xl md:text-6xl dark:text-zinc-50">
+                {tEnterprise("heading")}
+              </h1>
 
-            <p className="max-w-3xl font-sans leading-relaxed text-zinc-600 sm:text-base dark:text-zinc-400">
-              {tEnterprise("p0")}
-            </p>
-          </section>
+              <p className="max-w-3xl font-sans leading-relaxed text-zinc-600 sm:text-base dark:text-zinc-400">
+                {tEnterprise("p0")}
+              </p>
+            </section>
 
-          {/* 2. The "Intelligence Map" (2-Column Grid) */}
-          <section className="mx-auto max-w-7xl border-t border-zinc-300 px-4 pt-16 md:px-8 dark:border-zinc-800">
-            <div className="grid items-stretch gap-12 lg:grid-cols-2">
-              {/* Left Column (The Terminal) */}
-              <div className="flex flex-col">
-                <div className="flex h-full w-full flex-col overflow-hidden rounded-none border border-zinc-800 bg-zinc-950">
-                  {/* Terminal Content */}
-                  <div className="flex-1 space-y-4 overflow-x-auto p-4 font-mono text-sm leading-relaxed text-zinc-500 select-all md:p-6">
-                    {/* Command Prompt */}
-                    <div className="text-zinc-500">
-                      <span>$ </span>
-                      <span className="text-zinc-200">curl -X GET </span>
-                      <span className="text-zinc-400">
-                        &quot;https://api.donation.watch/v1/donations?donor=Harborne&quot;
-                      </span>
-                    </div>
-
-                    {/* JSON Output */}
-                    <div className="space-y-1 text-zinc-400">
-                      <div>
-                        <span className="text-zinc-500">&#123;</span>
+            {/* 2. The "Intelligence Map" (2-Column Grid) */}
+            <section className="mx-auto max-w-7xl border-t border-zinc-300 px-4 pt-16 md:px-8 dark:border-zinc-800">
+              <div className="grid items-stretch gap-12 lg:grid-cols-2">
+                {/* Left Column (The Terminal) */}
+                <div className="flex flex-col">
+                  <div className="flex h-full w-full flex-col overflow-hidden rounded-none border border-zinc-800 bg-zinc-950">
+                    {/* Terminal Content */}
+                    <div
+                      tabIndex={0}
+                      className="flex-1 space-y-4 overflow-x-auto p-4 font-mono text-sm leading-relaxed text-zinc-500 select-all md:p-6"
+                    >
+                      {/* Command Prompt */}
+                      <div className="text-zinc-500">
+                        <span>$ </span>
+                        <span className="text-zinc-200">curl -X GET </span>
+                        <span className="text-zinc-400">
+                          &quot;https://api.donation.watch/v1/donations?donor=Harborne&quot;
+                        </span>
                       </div>
-                      <div className="pl-4">
-                        <span className="text-zinc-500">&quot;data&quot;</span>:{" "}
-                        <span className="text-zinc-500">[</span>
-                        <div className="pl-4">
+
+                      {/* JSON Output */}
+                      <div className="space-y-1 text-zinc-400">
+                        <div>
                           <span className="text-zinc-500">&#123;</span>
+                        </div>
+                        <div className="pl-4">
+                          <span className="text-zinc-500">
+                            &quot;data&quot;
+                          </span>
+                          : <span className="text-zinc-500">[</span>
+                          <div className="pl-4">
+                            <span className="text-zinc-500">&#123;</span>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;id&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;d651c6c0-7f28-5a2a-bf30-4e38e8334460&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;date&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;2025-01-08&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;receiver&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;Reform UK&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;donation_type&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;monetary donation&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;donor&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;Christopher Harborne&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;amount&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-emerald-500">9000000</span>,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;currency&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;GBP&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;upstream_id&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;C0833694&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;source_registry&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;UK Electoral Commission&quot;
+                              </span>
+                              ,
+                            </div>
+                            <div className="pl-4">
+                              <span className="text-zinc-500">
+                                &quot;country&quot;
+                              </span>
+                              :{" "}
+                              <span className="text-sky-400">
+                                &quot;GB&quot;
+                              </span>
+                            </div>
+                            <span className="text-zinc-500">&#125;</span>
+                          </div>
+                          <span className="text-zinc-500">]</span>,
+                        </div>
+                        <div className="pl-4">
+                          <span className="text-zinc-500">
+                            &quot;meta&quot;
+                          </span>
+                          : <span className="text-zinc-500">&#123;</span>
                           <div className="pl-4">
                             <span className="text-zinc-500">
-                              &quot;id&quot;
+                              &quot;total_records&quot;
                             </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;d651c6c0-7f28-5a2a-bf30-4e38e8334460&quot;
-                            </span>
-                            ,
+                            : <span className="text-emerald-500">1</span>,
                           </div>
                           <div className="pl-4">
                             <span className="text-zinc-500">
-                              &quot;date&quot;
+                              &quot;limit&quot;
                             </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;2025-01-08&quot;
-                            </span>
-                            ,
+                            : <span className="text-emerald-500">50</span>,
                           </div>
                           <div className="pl-4">
                             <span className="text-zinc-500">
-                              &quot;receiver&quot;
+                              &quot;offset&quot;
                             </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;Reform UK&quot;
-                            </span>
-                            ,
-                          </div>
-                          <div className="pl-4">
-                            <span className="text-zinc-500">
-                              &quot;donation_type&quot;
-                            </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;monetary donation&quot;
-                            </span>
-                            ,
-                          </div>
-                          <div className="pl-4">
-                            <span className="text-zinc-500">
-                              &quot;donor&quot;
-                            </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;Christopher Harborne&quot;
-                            </span>
-                            ,
-                          </div>
-                          <div className="pl-4">
-                            <span className="text-zinc-500">
-                              &quot;amount&quot;
-                            </span>
-                            : <span className="text-emerald-500">9000000</span>,
-                          </div>
-                          <div className="pl-4">
-                            <span className="text-zinc-500">
-                              &quot;currency&quot;
-                            </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;GBP&quot;
-                            </span>
-                            ,
-                          </div>
-                          <div className="pl-4">
-                            <span className="text-zinc-500">
-                              &quot;upstream_id&quot;
-                            </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;C0833694&quot;
-                            </span>
-                            ,
-                          </div>
-                          <div className="pl-4">
-                            <span className="text-zinc-500">
-                              &quot;source_registry&quot;
-                            </span>
-                            :{" "}
-                            <span className="text-sky-400">
-                              &quot;UK Electoral Commission&quot;
-                            </span>
-                            ,
-                          </div>
-                          <div className="pl-4">
-                            <span className="text-zinc-500">
-                              &quot;country&quot;
-                            </span>
-                            :{" "}
-                            <span className="text-sky-400">&quot;GB&quot;</span>
+                            : <span className="text-emerald-500">0</span>
                           </div>
                           <span className="text-zinc-500">&#125;</span>
                         </div>
-                        <span className="text-zinc-500">]</span>,
+                        <div>
+                          <span className="text-zinc-500">&#125;</span>
+                        </div>
                       </div>
-                      <div className="pl-4">
-                        <span className="text-zinc-500">&quot;meta&quot;</span>:{" "}
-                        <span className="text-zinc-500">&#123;</span>
-                        <div className="pl-4">
-                          <span className="text-zinc-500">
-                            &quot;total_records&quot;
-                          </span>
-                          : <span className="text-emerald-500">1</span>,
-                        </div>
-                        <div className="pl-4">
-                          <span className="text-zinc-500">
-                            &quot;limit&quot;
-                          </span>
-                          : <span className="text-emerald-500">50</span>,
-                        </div>
-                        <div className="pl-4">
-                          <span className="text-zinc-500">
-                            &quot;offset&quot;
-                          </span>
-                          : <span className="text-emerald-500">0</span>
-                        </div>
-                        <span className="text-zinc-500">&#125;</span>
+                    </div>
+                  </div>
+
+                  {/* Draft disclaimer */}
+                  <p className="mt-3 font-sans text-sm tracking-wide text-zinc-500 italic">
+                    {tEnterprise("draft_schema")}
+                  </p>
+                </div>
+
+                {/* Right Column (Engine Specifications) */}
+                <div className="flex flex-col justify-between space-y-6 py-2">
+                  <div>
+                    <h2 className="mb-8 font-mono text-sm font-bold tracking-widest text-zinc-500 uppercase">
+                      {tEnterprise("engine_specs.title")}
+                    </h2>
+
+                    <div className="space-y-8">
+                      {/* Feature 1 */}
+                      <div className="border-b border-zinc-300 pb-6 dark:border-zinc-800">
+                        <h3 className="mb-2 font-mono font-bold tracking-wider text-zinc-900 uppercase dark:text-zinc-100">
+                          {tEnterprise("engine_specs.s0.title")}
+                        </h3>
+                        <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
+                          {tEnterprise("engine_specs.s0.description")}
+                        </p>
                       </div>
-                      <div>
-                        <span className="text-zinc-500">&#125;</span>
+
+                      {/* Feature 2 */}
+                      <div className="border-b border-zinc-300 pb-6 dark:border-zinc-800">
+                        <h3 className="mb-2 font-mono font-bold tracking-wider text-zinc-900 uppercase dark:text-zinc-100">
+                          {tEnterprise("engine_specs.s1.title")}
+                        </h3>
+                        <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
+                          {tEnterprise("engine_specs.s1.description")}
+                        </p>
+                      </div>
+
+                      {/* Feature 3 */}
+                      <div className="pb-2">
+                        <h3 className="mb-2 font-mono font-bold tracking-wider text-zinc-900 uppercase dark:text-zinc-100">
+                          {tEnterprise("engine_specs.s2.title")}
+                        </h3>
+                        <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
+                          {tEnterprise("engine_specs.s2.description")}
+                        </p>
                       </div>
                     </div>
                   </div>
                 </div>
-
-                {/* Draft disclaimer */}
-                <p className="mt-3 font-sans text-sm tracking-wide text-zinc-500 italic">
-                  {tEnterprise("draft_schema")}
-                </p>
               </div>
+            </section>
 
-              {/* Right Column (Engine Specifications) */}
-              <div className="flex flex-col justify-between space-y-6 py-2">
-                <div>
-                  <h3 className="mb-8 font-mono text-sm font-bold tracking-widest text-zinc-500 uppercase">
-                    {tEnterprise("engine_specs.title")}
-                  </h3>
-
-                  <div className="space-y-8">
-                    {/* Feature 1 */}
-                    <div className="border-b border-zinc-300 pb-6 dark:border-zinc-800">
-                      <h4 className="mb-2 font-mono font-bold tracking-wider text-zinc-900 uppercase dark:text-zinc-100">
-                        {tEnterprise("engine_specs.s0.title")}
-                      </h4>
-                      <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
-                        {tEnterprise("engine_specs.s0.description")}
-                      </p>
-                    </div>
-
-                    {/* Feature 2 */}
-                    <div className="border-b border-zinc-300 pb-6 dark:border-zinc-800">
-                      <h4 className="mb-2 font-mono font-bold tracking-wider text-zinc-900 uppercase dark:text-zinc-100">
-                        {tEnterprise("engine_specs.s1.title")}
-                      </h4>
-                      <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
-                        {tEnterprise("engine_specs.s1.description")}
-                      </p>
-                    </div>
-
-                    {/* Feature 3 */}
-                    <div className="pb-2">
-                      <h4 className="mb-2 font-mono font-bold tracking-wider text-zinc-900 uppercase dark:text-zinc-100">
-                        {tEnterprise("engine_specs.s2.title")}
-                      </h4>
-                      <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
-                        {tEnterprise("engine_specs.s2.description")}
-                      </p>
-                    </div>
+            {/* 3. Social Proof Ticker */}
+            <section className="w-full border-y border-zinc-300 bg-zinc-50/50 py-8 dark:border-zinc-800 dark:bg-zinc-950/20">
+              <div className="mx-auto max-w-7xl px-4 md:px-8">
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-3 font-mono uppercase">
+                  <span className="font-bold tracking-widest text-zinc-900 uppercase select-none dark:text-zinc-100">
+                    {tEnterprise("monitoring.title")}
+                  </span>
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 text-zinc-600 md:gap-x-4 dark:text-zinc-400">
+                    <span className="uppercase">
+                      {tEnterprise("monitoring.financial")}
+                    </span>
+                    <span
+                      className="hidden text-zinc-500 md:inline dark:text-zinc-800"
+                      aria-hidden="true"
+                    >
+                      |
+                    </span>
+                    <span className="uppercase">
+                      {tEnterprise("monitoring.government")}
+                    </span>
+                    <span
+                      className="hidden text-zinc-500 md:inline dark:text-zinc-800"
+                      aria-hidden="true"
+                    >
+                      |
+                    </span>
+                    <span className="uppercase">
+                      {tEnterprise("monitoring.universities")}
+                    </span>
+                    <span
+                      className="hidden text-zinc-500 md:inline dark:text-zinc-800"
+                      aria-hidden="true"
+                    >
+                      |
+                    </span>
+                    <span className="uppercase">
+                      {tEnterprise("monitoring.universities")}
+                    </span>
                   </div>
                 </div>
               </div>
-            </div>
-          </section>
+            </section>
 
-          {/* 3. Social Proof Ticker */}
-          <section className="w-full border-y border-zinc-300 bg-zinc-50/50 py-8 dark:border-zinc-800 dark:bg-zinc-950/20">
-            <div className="mx-auto max-w-7xl px-4 md:px-8">
-              <div className="flex flex-wrap items-center gap-x-4 gap-y-3 font-mono uppercase">
-                <span className="font-bold tracking-widest text-zinc-900 uppercase select-none dark:text-zinc-100">
-                  {tEnterprise("monitoring.title")}
-                </span>
-                <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 text-zinc-600 md:gap-x-4 dark:text-zinc-400">
-                  <span className="uppercase">
-                    {tEnterprise("monitoring.financial")}
-                  </span>
-                  <span
-                    className="hidden text-zinc-500 md:inline dark:text-zinc-800"
-                    aria-hidden="true"
-                  >
-                    |
-                  </span>
-                  <span className="uppercase">
-                    {tEnterprise("monitoring.government")}
-                  </span>
-                  <span
-                    className="hidden text-zinc-500 md:inline dark:text-zinc-800"
-                    aria-hidden="true"
-                  >
-                    |
-                  </span>
-                  <span className="uppercase">
-                    {tEnterprise("monitoring.universities")}
-                  </span>
-                  <span
-                    className="hidden text-zinc-500 md:inline dark:text-zinc-800"
-                    aria-hidden="true"
-                  >
-                    |
-                  </span>
-                  <span className="uppercase">
-                    {tEnterprise("monitoring.universities")}
-                  </span>
+            {/* 4. Private Beta Waitlist Section */}
+            <section className="mx-auto max-w-7xl px-4 pt-6 md:px-8">
+              <div className="grid items-start gap-12 lg:grid-cols-5">
+                <div className="space-y-6 lg:col-span-2">
+                  <h2 className="font-sans text-3xl leading-none font-extrabold tracking-tight text-zinc-900 uppercase sm:text-4xl dark:text-zinc-50">
+                    {tEnterprise("register.title")}
+                  </h2>
+
+                  <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
+                    {tEnterprise("register.p0")}
+                  </p>
+                </div>
+
+                {/* Form */}
+                <div className="lg:col-span-3">
+                  <div className="w-full rounded-none border border-zinc-300 bg-white p-6 shadow-none md:p-8 dark:border-zinc-800 dark:bg-zinc-950">
+                    <EnterpriseContactForm
+                      successTitle={tEnterprise("form.successTitle")}
+                      successMessageTemplate={tEnterprise(
+                        "form.successMessageTemplate",
+                      )}
+                      submitAnotherButton={tEnterprise(
+                        "form.submitAnotherButton",
+                      )}
+                      formTitle={tEnterprise("form.formTitle")}
+                      labelFullName={tEnterprise("form.labelFullName")}
+                      labelWorkEmail={tEnterprise("form.labelWorkEmail")}
+                      labelOrganization={tEnterprise("form.labelOrganization")}
+                      labelQueryRequest={tEnterprise("form.labelQueryRequest")}
+                      consentText={tEnterprise("form.consentText")}
+                      buttonProcessing={tEnterprise("form.buttonProcessing")}
+                      buttonSubmit={tEnterprise("form.buttonSubmit")}
+                      errorFailedSubmit={tEnterprise("form.errorFailedSubmit")}
+                      errorUnexpected={tEnterprise("form.errorUnexpected")}
+                      turnstileLabel={tEnterprise("form.turnstileLabel")}
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </section>
-
-          {/* 4. Private Beta Waitlist Section */}
-          <section className="mx-auto max-w-7xl px-4 pt-6 md:px-8">
-            <div className="grid items-start gap-12 lg:grid-cols-5">
-              <div className="space-y-6 lg:col-span-2">
-                <h2 className="font-sans text-3xl leading-none font-extrabold tracking-tight text-zinc-900 uppercase sm:text-4xl dark:text-zinc-50">
-                  {tEnterprise("register.title")}
-                </h2>
-
-                <p className="font-sans leading-relaxed text-zinc-600 dark:text-zinc-400">
-                  {tEnterprise("register.p0")}
-                </p>
-              </div>
-
-              {/* Form */}
-              <div className="lg:col-span-3">
-                <div className="w-full rounded-none border border-zinc-300 bg-white p-6 shadow-none md:p-8 dark:border-zinc-800 dark:bg-zinc-950">
-                  <EnterpriseContactForm
-                    successTitle={tEnterprise("form.successTitle")}
-                    successMessageTemplate={tEnterprise(
-                      "form.successMessageTemplate",
-                    )}
-                    submitAnotherButton={tEnterprise(
-                      "form.submitAnotherButton",
-                    )}
-                    formTitle={tEnterprise("form.formTitle")}
-                    labelFullName={tEnterprise("form.labelFullName")}
-                    labelWorkEmail={tEnterprise("form.labelWorkEmail")}
-                    labelOrganization={tEnterprise("form.labelOrganization")}
-                    labelQueryRequest={tEnterprise("form.labelQueryRequest")}
-                    consentText={tEnterprise("form.consentText")}
-                    buttonProcessing={tEnterprise("form.buttonProcessing")}
-                    buttonSubmit={tEnterprise("form.buttonSubmit")}
-                    errorFailedSubmit={tEnterprise("form.errorFailedSubmit")}
-                    errorUnexpected={tEnterprise("form.errorUnexpected")}
-                    turnstileLabel={tEnterprise("form.turnstileLabel")}
-                  />
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </Article>
-    </NonCountryRootLayout>
+            </section>
+          </div>
+        </Article>
+      </NonCountryRootLayout>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -11,7 +11,7 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { OrganizationSchema } from "@/components/schema";
 import { Toaster } from "@/components/ui/sonner";
 import { SIDENAV_PERSISTENCE_KEY, THUMBNAIL_PREFIX } from "@/utils/config";
-import { filterClientMessages } from "@/utils/i18n-filter";
+import { filterLayoutMessages } from "@/utils/i18n-filter";
 import { LOCALES } from "@/utils/locales";
 import { baseOpenGraph, baseTwitter } from "@/utils/meta";
 import { notFoundMetadata } from "@/utils/not-found-metadata";
@@ -77,7 +77,7 @@ export default async function LangLayout(props: LayoutProps<"/[locale]">) {
       </head>
       <body className="min-h-screen w-full">
         <NuqsAdapter>
-          <Providers locale={locale} messages={filterClientMessages(messages)}>
+          <Providers locale={locale} messages={filterLayoutMessages(messages)}>
             {children}
           </Providers>
         </NuqsAdapter>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,6 +13,7 @@ import {
   FormattedCompactCurrency,
   FormattedNumber,
 } from "@/components/browser-based-formatter";
+import { ScopedClientIntlProvider } from "@/components/i18n/scoped-provider";
 import {
   Article,
   ArticleSection,
@@ -29,6 +30,8 @@ import { GITHUB_URL, THUMBNAIL_PREFIX } from "@/utils/config";
 import { COUNTRIES, COUNTRY_CONFIG, getCountryName } from "@/utils/countries";
 import { countryFlags } from "@/utils/country-flags";
 import { getCountryConfig } from "@/utils/data/get-country-config";
+import { getMessagesForLocale } from "@/utils/i18n-loader";
+import { pick } from "@/utils/i18n-pick";
 import {
   getPartyYearsSums,
   PartyStatField,
@@ -82,10 +85,11 @@ export default async function RootPage(props: PageProps<"/[locale]">) {
   setRequestLocale(params.locale);
 
   const { locale } = params;
-  const [t, tCountries, tRoot] = await Promise.all([
+  const [t, tCountries, tRoot, messages] = await Promise.all([
     getTranslations({ locale }),
     getTranslations({ locale, namespace: "countries" }),
     getTranslations({ locale, namespace: "root" }),
+    getMessagesForLocale(locale),
   ]);
   const countriesArray = [...COUNTRIES];
 
@@ -119,163 +123,169 @@ export default async function RootPage(props: PageProps<"/[locale]">) {
     });
   });
 
-  return (
-    <NonCountryRootLayout locale={locale}>
-      <AbsoluteMultipleColorsGradient
-        colors={[{ color: "#3730a3", width: 100 }]}
-      />
+  const pageMessages = pick(messages, ["root"]);
 
-      <header
-        aria-labelledby="hero-title"
-        className="relative flex min-h-64 flex-row items-center justify-center p-4 pt-14 sm:py-10 sm:pt-20"
-      >
-        <div className="z-1 container mx-auto lg:text-center">
-          <h1 className="mb-2 text-4xl font-bold sm:text-5xl" id="hero-title">
-            DonationWatch
-          </h1>
-          <p className="mb-4 text-xl sm:text-2xl">{tRoot("title")}</p>
-          <p className="mx-auto mb-4 text-base sm:text-lg lg:max-w-2xl">
-            {tRoot("subtitle")}
-          </p>
-          <div className="flex justify-center">
-            <div className="inline-block text-left">
-              <DetectedCountry />
+  return (
+    <ScopedClientIntlProvider messages={pageMessages}>
+      <NonCountryRootLayout locale={locale}>
+        <AbsoluteMultipleColorsGradient
+          colors={[{ color: "#3730a3", width: 100 }]}
+        />
+
+        <header
+          aria-labelledby="hero-title"
+          className="relative flex min-h-64 flex-row items-center justify-center p-4 pt-14 sm:py-10 sm:pt-20"
+        >
+          <div className="z-1 container mx-auto lg:text-center">
+            <h1 className="mb-2 text-4xl font-bold sm:text-5xl" id="hero-title">
+              DonationWatch
+            </h1>
+            <p className="mb-4 text-xl sm:text-2xl">{tRoot("title")}</p>
+            <p className="mx-auto mb-4 text-base sm:text-lg lg:max-w-2xl">
+              {tRoot("subtitle")}
+            </p>
+            <div className="flex justify-center">
+              <div className="inline-block text-left">
+                <DetectedCountry />
+              </div>
             </div>
           </div>
-        </div>
-      </header>
+        </header>
 
-      <Article fullWidth skipTitleOffset>
-        <ArticleSectionWrapper id="stats">
-          <ArticleSectionOneColumns>
-            <ArticleSectionColumn>
-              <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-                <div className="text-center">
-                  <MetaCard
-                    title={tRoot("stats.countries")}
-                    value={<FormattedNumber value={trackedCountries} />}
-                  />
+        <Article fullWidth skipTitleOffset>
+          <ArticleSectionWrapper id="stats">
+            <ArticleSectionOneColumns>
+              <ArticleSectionColumn>
+                <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                  <div className="text-center">
+                    <MetaCard
+                      title={tRoot("stats.countries")}
+                      value={<FormattedNumber value={trackedCountries} />}
+                    />
+                  </div>
+                  <div className="text-center">
+                    <MetaCard
+                      title={tRoot("stats.parties")}
+                      value={<FormattedNumber value={trackedParties} />}
+                    />
+                  </div>
+                  <div className="text-center">
+                    <MetaCard
+                      title={tRoot("stats.donations")}
+                      value={<FormattedNumber value={trackedDonations} />}
+                    />
+                  </div>
+                  <div className="text-center">
+                    <MetaCard
+                      title={tRoot("stats.currencies")}
+                      value={Object.keys(currencyTotals).length}
+                    />
+                  </div>
                 </div>
-                <div className="text-center">
-                  <MetaCard
-                    title={tRoot("stats.parties")}
-                    value={<FormattedNumber value={trackedParties} />}
-                  />
-                </div>
-                <div className="text-center">
-                  <MetaCard
-                    title={tRoot("stats.donations")}
-                    value={<FormattedNumber value={trackedDonations} />}
-                  />
-                </div>
-                <div className="text-center">
-                  <MetaCard
-                    title={tRoot("stats.currencies")}
-                    value={Object.keys(currencyTotals).length}
-                  />
-                </div>
-              </div>
-            </ArticleSectionColumn>
-          </ArticleSectionOneColumns>
-        </ArticleSectionWrapper>
+              </ArticleSectionColumn>
+            </ArticleSectionOneColumns>
+          </ArticleSectionWrapper>
 
-        <ArticleSection title={tRoot("countries.title")} id="countries">
-          <p className="mb-6 text-gray-600 dark:text-gray-400">
-            {tRoot("countries.subtitle")}
-          </p>
-          <nav
-            aria-label={t("header.country_selection")}
-            className="grid grid-cols-2 gap-2 lg:grid-cols-3 xl:gap-4 2xl:grid-cols-5"
-          >
-            {countriesArray
-              .toSorted((a, b) => {
-                const nameA = getCountryName(COUNTRY_CONFIG[a], tCountries);
-                const nameB = getCountryName(COUNTRY_CONFIG[b], tCountries);
-                return nameA.localeCompare(nameB, locale);
-              })
-              .map((countryId) => {
-                const config = COUNTRY_CONFIG[countryId];
-                const countryName = getCountryName(config, tCountries);
+          <ArticleSection title={tRoot("countries.title")} id="countries">
+            <p className="mb-6 text-gray-600 dark:text-gray-400">
+              {tRoot("countries.subtitle")}
+            </p>
+            <nav
+              aria-label={t("header.country_selection")}
+              className="grid grid-cols-2 gap-2 lg:grid-cols-3 xl:gap-4 2xl:grid-cols-5"
+            >
+              {countriesArray
+                .toSorted((a, b) => {
+                  const nameA = getCountryName(COUNTRY_CONFIG[a], tCountries);
+                  const nameB = getCountryName(COUNTRY_CONFIG[b], tCountries);
+                  return nameA.localeCompare(nameB, locale);
+                })
+                .map((countryId) => {
+                  const config = COUNTRY_CONFIG[countryId];
+                  const countryName = getCountryName(config, tCountries);
 
-                return (
-                  <Link
-                    prefetch={false}
-                    key={countryId}
-                    href={`/${locale}/${countryId}`}
-                    className="group flex gap-2 rounded border border-gray-200 px-2 py-1 transition-colors hover:border-gray-300 hover:bg-gray-50 xl:p-2 dark:border-gray-700 dark:hover:border-gray-600 dark:hover:bg-gray-800/50"
-                  >
-                    <div className="flex w-8 shrink-0 items-center justify-center 2xl:w-16">
-                      <Image
-                        aria-hidden="true"
-                        height={18}
-                        className="max-h-full rounded-xs"
-                        src={countryFlags[countryId]}
-                        alt=""
-                      />
-                    </div>
-                    <div className="grow overflow-hidden">
-                      <div className="group-hover:text-primary-600 dark:group-hover:text-primary-400 truncate text-sm font-medium xl:text-base">
-                        {countryName}
-                      </div>
-                      <div className="text-xs text-slate-500 xl:text-sm dark:text-slate-300">
-                        <FormattedCompactCurrency
-                          value={sumPerCountry[countryId] ?? 0}
-                          currency={config.currency}
+                  return (
+                    <Link
+                      prefetch={false}
+                      key={countryId}
+                      href={`/${locale}/${countryId}`}
+                      className="group flex gap-2 rounded border border-gray-200 px-2 py-1 transition-colors hover:border-gray-300 hover:bg-gray-50 xl:p-2 dark:border-gray-700 dark:hover:border-gray-600 dark:hover:bg-gray-800/50"
+                    >
+                      <div className="flex w-8 shrink-0 items-center justify-center 2xl:w-16">
+                        <Image
+                          aria-hidden="true"
+                          height={18}
+                          className="max-h-full rounded-xs"
+                          src={countryFlags[countryId]}
+                          alt=""
                         />
                       </div>
-                    </div>
-                  </Link>
-                );
-              })}
-          </nav>
-        </ArticleSection>
-
-        <ArticleSection title={tRoot("why.title")} id="why-transparency">
-          <p className="text-gray-700 dark:text-gray-300">{tRoot("why.p0")}</p>
-        </ArticleSection>
-
-        <div className="grid gap-8 lg:grid-cols-2">
-          <ArticleSection
-            title={"Enterprise API (Beta)"}
-            id="enterprise-api-beta"
-          >
-            <p className="mb-6 text-gray-700 dark:text-gray-300">
-              Need programmatic access to cross-registry entity mappings? We are
-              currently engineering a high-availability REST API with OpenAPI
-              specifications, designed specifically for institutional compliance
-              and risk analysis teams.
-            </p>
-            <div>
-              <Button variant={"outline"} asChild={true}>
-                <Link href={`/${locale}/enterprise`}>
-                  <Server />
-                  Join the Waitlist
-                </Link>
-              </Button>
-            </div>
+                      <div className="grow overflow-hidden">
+                        <div className="group-hover:text-primary-600 dark:group-hover:text-primary-400 truncate text-sm font-medium xl:text-base">
+                          {countryName}
+                        </div>
+                        <div className="text-xs text-slate-500 xl:text-sm dark:text-slate-300">
+                          <FormattedCompactCurrency
+                            value={sumPerCountry[countryId] ?? 0}
+                            currency={config.currency}
+                          />
+                        </div>
+                      </div>
+                    </Link>
+                  );
+                })}
+            </nav>
           </ArticleSection>
-          <ArticleSection title={tRoot("open_source.title")} id="open-source">
+
+          <ArticleSection title={tRoot("why.title")} id="why-transparency">
             <p className="text-gray-700 dark:text-gray-300">
-              <Translation
-                t={tRoot}
-                translationId={"open_source.p0"}
-                variables={{
-                  github: (
-                    <a
-                      href={GITHUB_URL}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300 underline"
-                    >
-                      GitHub
-                    </a>
-                  ),
-                }}
-              />
+              {tRoot("why.p0")}
             </p>
           </ArticleSection>
-        </div>
-      </Article>
-    </NonCountryRootLayout>
+
+          <div className="grid gap-8 lg:grid-cols-2">
+            <ArticleSection
+              title={"Enterprise API (Beta)"}
+              id="enterprise-api-beta"
+            >
+              <p className="mb-6 text-gray-700 dark:text-gray-300">
+                Need programmatic access to cross-registry entity mappings? We
+                are currently engineering a high-availability REST API with
+                OpenAPI specifications, designed specifically for institutional
+                compliance and risk analysis teams.
+              </p>
+              <div>
+                <Button variant={"outline"} asChild={true}>
+                  <Link href={`/${locale}/enterprise`}>
+                    <Server />
+                    Join the Waitlist
+                  </Link>
+                </Button>
+              </div>
+            </ArticleSection>
+            <ArticleSection title={tRoot("open_source.title")} id="open-source">
+              <p className="text-gray-700 dark:text-gray-300">
+                <Translation
+                  t={tRoot}
+                  translationId={"open_source.p0"}
+                  variables={{
+                    github: (
+                      <a
+                        href={GITHUB_URL}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300 underline"
+                      >
+                        GitHub
+                      </a>
+                    ),
+                  }}
+                />
+              </p>
+            </ArticleSection>
+          </div>
+        </Article>
+      </NonCountryRootLayout>
+    </ScopedClientIntlProvider>
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NextIntlClientProvider } from "next-intl";
 import { createContext, useEffect, useMemo, useState } from "react";
 
-import type { ClientMessages } from "@/utils/i18n-filter";
+import type { LayoutMessages } from "@/utils/i18n-filter";
 import type { BrowserBasedLocale, ConstLocale } from "@/utils/locales";
 
 import { SidebarProvider } from "@/components/ui/sidebar";
@@ -20,7 +20,7 @@ export const Providers = ({
   messages,
 }: PropsWithChildren<{
   locale: ConstLocale;
-  messages: ClientMessages;
+  messages: LayoutMessages;
 }>) => {
   const [queryClient] = useState(
     () =>
@@ -39,6 +39,7 @@ export const Providers = ({
   return (
     <NextIntlClientProvider
       locale={locale}
+      timeZone="UTC"
       messages={messages as unknown as Messages}
     >
       <BrowserBasedLocaleProvider locale={locale}>

--- a/src/components/i18n/scoped-provider.tsx
+++ b/src/components/i18n/scoped-provider.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { Messages } from "next-intl";
+import type { PropsWithChildren } from "react";
+
+import {
+  NextIntlClientProvider,
+  useLocale,
+  useMessages,
+  useTimeZone,
+} from "next-intl";
+
+export function ScopedClientIntlProvider({
+  messages,
+  children,
+}: PropsWithChildren<{ messages: Partial<Messages> }>) {
+  const locale = useLocale();
+  const timeZone = useTimeZone();
+  const parentMessages = useMessages();
+  const mergedMessages = { ...parentMessages, ...messages };
+
+  return (
+    <NextIntlClientProvider
+      locale={locale}
+      timeZone={timeZone}
+      messages={mergedMessages}
+    >
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -9,6 +9,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
 
   return {
     locale,
+    timeZone: "UTC",
     messages: (await import(`../messages/${locale}.json`)).default,
   };
 });

--- a/src/utils/i18n-filter.ts
+++ b/src/utils/i18n-filter.ts
@@ -16,7 +16,6 @@ export const SERVER_ONLY_NAMESPACES = [
   "thanks",
   "export",
   "compare_parties_page",
-  "page_title",
   "per_year",
   "enterprise",
 ] as const;
@@ -34,4 +33,51 @@ export function filterClientMessages(messages: Messages): ClientMessages {
       ([key]) => !SERVER_ONLY_NAMESPACES.includes(key as ServerOnlyNamespace),
     ),
   ) as ClientMessages;
+}
+
+/**
+ * Namespaces required by global layout shells (navigation, sidebar, footer, search, countries list).
+ */
+export const LAYOUT_NAMESPACES = [
+  "navigation",
+  "sidebar",
+  "search",
+  "common",
+  "sort",
+  "footer",
+  "header",
+  "actions",
+  "countries",
+  "ref_countries",
+  "data",
+  "detect_country",
+  "copyright",
+  "description",
+  "title",
+  "sum",
+  "donation_count",
+  "average",
+  "donations_by_party",
+  "donations_per_year",
+  "party_donations",
+  "more",
+  "data_since",
+  "view_party",
+  "faq",
+  "over_min_public_amount",
+  "over_threshold",
+  "prelim_data",
+  "donor_dialog",
+] as const;
+
+type LayoutNamespace = (typeof LAYOUT_NAMESPACES)[number];
+
+export type LayoutMessages = Pick<Messages, LayoutNamespace>;
+
+export function filterLayoutMessages(messages: Messages): LayoutMessages {
+  return Object.fromEntries(
+    Object.entries(messages).filter(([key]) =>
+      LAYOUT_NAMESPACES.includes(key as LayoutNamespace),
+    ),
+  ) as LayoutMessages;
 }

--- a/src/utils/i18n-loader.ts
+++ b/src/utils/i18n-loader.ts
@@ -1,0 +1,19 @@
+import type { Messages } from "next-intl";
+
+const messageMap: Record<string, () => Promise<{ default: Messages }>> = {
+  cs: () => import("../messages/cs.json"),
+  de: () => import("../messages/de.json"),
+  en: () => import("../messages/en.json"),
+  et: () => import("../messages/et.json"),
+  fr: () => import("../messages/fr.json"),
+  hr: () => import("../messages/hr.json"),
+  lv: () => import("../messages/lv.json"),
+  nl: () => import("../messages/nl.json"),
+  no: () => import("../messages/no.json"),
+  uk: () => import("../messages/uk.json"),
+};
+
+export async function getMessagesForLocale(locale: string): Promise<Messages> {
+  const loader = messageMap[locale] || messageMap.en;
+  return loader().then((mod) => mod.default);
+}

--- a/src/utils/i18n-pick.ts
+++ b/src/utils/i18n-pick.ts
@@ -1,0 +1,12 @@
+export function pick<T extends object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+): Pick<T, K> {
+  const result = {} as Pick<T, K>;
+  for (const key of keys) {
+    if (key in obj) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Description

Further splits page translations to avoid bloating rehydration with unused translation strings

after: 2.8 GiB (3,031,142,400 bytes)

before: 3.1 GiB (3,379,040,256 bytes)


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Data update/addition
- [ ] Documentation update
- [x] Refactoring

## Testing

- [x] Unit tests pass (`pnpm test:unit`)
- [x] Lint passes (`pnpm lint`)
- [x] E2E tests pass (`pnpm test:e2e`) - if UI changes
